### PR TITLE
Client: Allow more strings to be translated

### DIFF
--- a/Client/chatroomform.ui
+++ b/Client/chatroomform.ui
@@ -215,13 +215,13 @@
         </sizepolicy>
        </property>
        <property name="title">
-        <string>Status</string>
+        <string comment="Status">Status</string>
        </property>
        <layout class="QFormLayout" name="formLayout">
         <item row="2" column="0">
          <widget class="QLabel" name="RulesLabel">
           <property name="text">
-           <string>Rules</string>
+           <string comment="TitleRules">Rules</string>
           </property>
          </widget>
         </item>

--- a/Client/chatwindow.ui
+++ b/Client/chatwindow.ui
@@ -91,12 +91,12 @@
          </attribute>
          <column>
           <property name="text">
-           <string>Name</string>
+           <string comment="ChatwindowName">Name</string>
           </property>
          </column>
          <column>
           <property name="text">
-           <string>Type</string>
+           <string comment="ChatwindowType">Type</string>
           </property>
          </column>
         </widget>

--- a/Client/gamemanager.cpp
+++ b/Client/gamemanager.cpp
@@ -365,7 +365,7 @@ void GameManager::peerPartedChannel(QString channel, QString peer) const
 	}
 	// Spectator or pending player left
 	else {
-		QString langStr = tr("%s left."); // TODO: Needs a translation string!
+		QString langStr = tr("%s left.","Launcher:PlayerLeave");
 		widget->chatWindow()->statusMessage(QString::asprintf(langStr.toUtf8().data(), peer.toUtf8().data()));
 	}
 	// Remove from chatwindow

--- a/Client/gamemanager.cpp
+++ b/Client/gamemanager.cpp
@@ -307,9 +307,9 @@ void GameManager::channelJoined(QString channel, NetPeerList peers) const
 
 		// Populate userlist
 		if (peer.status == 1) {
-			widget->chatWindow()->addUser(peer.username, QString("Player %1").arg(playernum));
+			widget->chatWindow()->addUser(peer.username, QString(tr("Player %1", "Launcher:ChatwindowPl")).arg(playernum));
 		} else if (peer.status == 2) {
-			widget->chatWindow()->addUser(peer.username, "Spectator");
+			widget->chatWindow()->addUser(peer.username, tr("Spectator","Launcher:ChatwindowSp"));
 		}
 	}
 }
@@ -573,9 +573,9 @@ void GameManager::peerStatusReceived(QString channel, QString peer, uchar status
 
 	// Add to userlist
 	if (status == 1)
-		widget->chatWindow()->addUser(peer, QString("Player %1").arg(pln));
+		widget->chatWindow()->addUser(peer, QString(tr("Player %1", "Launcher:ChatwindowPl")).arg(pln));
 	else if (status == 2)
-		widget->chatWindow()->addUser(peer, "Spectator");
+		widget->chatWindow()->addUser(peer, tr("Spectator","Launcher:ChatwindowSp"));
 }
 
 void GameManager::updateControls(GameWidget* game)

--- a/Client/settingsdialog.ui
+++ b/Client/settingsdialog.ui
@@ -344,14 +344,14 @@
           <item>
            <widget class="QCheckBox" name="AllowCrashDumpsCheckBox">
             <property name="text">
-             <string>Allow sending crash dumps and error logs</string>
+             <string comment="TelemetryCrashCheckbox">Allow sending crash dumps and error logs</string>
             </property>
            </widget>
           </item>
           <item>
            <widget class="QCheckBox" name="AllowUsageStatisticsCheckBox">
             <property name="text">
-             <string>Allow sending usage statistics and telemetry</string>
+             <string comment="TelemetryStatisticCheckbox">Allow sending usage statistics and telemetry</string>
             </property>
            </widget>
           </item>

--- a/Client/telemetrydialog.ui
+++ b/Client/telemetrydialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Puyo VS Telemetry</string>
+   <string comment="TelemetryTitle">Puyo VS Telemetry</string>
   </property>
   <property name="windowIcon">
    <iconset resource="client.qrc">
@@ -21,7 +21,7 @@
    <item>
     <widget class="QLabel" name="explanationLabel">
      <property name="text">
-      <string>Would you like to send crash dumps and/or usage information to the Puyo VS team? This information is kept private and will be used to find bugs and prioritize improvements. This is completely optional, but helpful to us.</string>
+      <string comment="TelemetryNotice">Would you like to send crash dumps and/or usage information to the Puyo VS team? This information is kept private and will be used to find bugs and prioritize improvements. This is completely optional, but helpful to us.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -31,14 +31,14 @@
    <item>
     <widget class="QCheckBox" name="allowCrashDumpsCheckBox">
      <property name="text">
-      <string>Allow sending crash dumps and error logs</string>
+      <string comment="TelemetryCrashCheckbox">Allow sending crash dumps and error logs</string>
      </property>
     </widget>
    </item>
    <item>
     <widget class="QCheckBox" name="allowUsageStatisticsCheckBox">
      <property name="text">
-      <string>Allow sending usage statistics and telemetry</string>
+      <string comment="TelemetryStatisticCheckbox">Allow sending usage statistics and telemetry</string>
      </property>
     </widget>
    </item>
@@ -58,7 +58,7 @@
    <item>
     <widget class="QLabel" name="explainConfigLabel">
      <property name="text">
-      <string>&lt;i&gt;If you change your mind, you can disable or enable these options in Settings.&lt;/i&gt;</string>
+      <string comment="TelemetrySettingsRemind">&lt;i&gt;If you change your mind, you can disable or enable these options in Settings.&lt;/i&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/Test/Language/English.json
+++ b/Test/Language/English.json
@@ -197,7 +197,12 @@
 		"EnterRoomPassword":	"Enter the password for this game room:",
 		"PrivateRoom":		"Private room",
 		"WrongPassword":	"Wrong Password!",
-		"SendPrivate":		"Send private"
+		"SendPrivate":		"Send private",
+
+		"TelemetryTitle":	"Puyo VS Telemetry",
+		"TelemetryNotice":	"Would you like to send crash dumps and/or usage information to the Puyo VS team? This information is kept private and will be used to find bugs and prioritize improvements. This is completely optional, but helpful to us.",
+		"TelemetryCrashCheckbox":	"Allow sending crash dumps and error logs",
+		"TelemetryStatisticCheckbox":	"Allow sending usage statistics and telemetry"
 	},
 	"Messages":
 	{


### PR DESCRIPTION
There were several strings in the Client (such as the ChatWindow) that weren't being affected by translations. This patch should fix that. Also now we fully allow the translation of the Telemetry dialog.