### PR TITLE
Align filenames with the Qt spec

### DIFF
--- a/Client/common.cpp
+++ b/Client/common.cpp
@@ -2,6 +2,7 @@
 #include "../Puyolib/Game.h"
 #include <QCryptographicHash>
 #include <QDesktopServices>
+#include <QDir>
 #include <QKeyEvent>
 #include <QMessageBox>
 #include <QObject>
@@ -47,14 +48,46 @@ QString getCryptographicHash(QString str)
 	return QString(QCryptographicHash::hash(s.toUtf8(), QCryptographicHash::Md5).toHex());
 }
 
-QString getDataLocation()
+QString verifyFolderExistence(QString fn)
+{
+	// Create the folder if it doesn't already
+	if (!QDir(fn).exists())
+	{
+		QDir().mkpath(fn);
+	}
+	return fn;
+}
+
+QString getCacheLocation()
 {
 #if QT_VERSION >= 0x050000
+	//Qt 5
+	return verifyFolderExistence(QStandardPaths::writableLocation(QStandardPaths::CacheLocation));
+#else
+	return verifyFolderExistence(QDesktopServices::storageLocation(QDesktopServices::CacheLocation));
+#endif
+}
+
+QString getDataLocation()
+{
+
+#if QT_VERSION >= 0x050000
 	// Qt5: QStandardPaths::StandardLocation
-	return QStandardPaths::writableLocation(QStandardPaths::DataLocation);
+	return verifyFolderExistence(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
 #else
 	// Qt4
-	return QDesktopServices::storageLocation(QDesktopServices::DataLocation);
+	return verifyFolderExistence(QDesktopServices::storageLocation(QDesktopServices::DataLocation));
+#endif
+}
+
+QString getSettingsLocation()
+{
+#if QT_VERSION >= 0x050000
+	// Qt5
+	return verifyFolderExistence(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation));
+#else
+	// Qt4: revert to Data location
+	return verifyFolderExistence(QDesktopServices::storageLocation(QDesktopServices::DataLocation));
 #endif
 }
 

--- a/Client/common.h
+++ b/Client/common.h
@@ -29,7 +29,9 @@ typedef QList<GameModePair> GameModeList;
 typedef QListIterator<QPair<ppvs::Rules, QString>> GameModeListIterator;
 GameModeList getModeList();
 void readRulesetString(QString str, ppvs::RuleSetInfo* rs);
+QString getCacheLocation();
 QString getDataLocation();
+QString getSettingsLocation();
 QString createRulesetString(ppvs::RuleSetInfo* rs);
 
 namespace ilib {

--- a/Client/main.h
+++ b/Client/main.h
@@ -3,7 +3,7 @@
 
 #ifndef PREFIX
 #if defined(Q_OS_WIN)
-#define PREFIX "C:\\PuyoVS"
+#define PREFIX "C:\\Program Files"
 #elif defined(Q_OS_MAC) && defined(__aarch64__)
 #define PREFIX "/opt/homebrew"
 #else
@@ -12,7 +12,7 @@
 #endif
 
 #if defined(Q_OS_WIN)
-static const char* defaultAssetPath = PREFIX;
+static const char* defaultAssetPath = PREFIX "\\PuyoVS";
 #else
 static const char* defaultAssetPath = PREFIX "/share/puyovs";
 #endif

--- a/Client/playlist.cpp
+++ b/Client/playlist.cpp
@@ -72,7 +72,7 @@ CacheDB* CacheDB::instance = nullptr;
 
 CacheDB::CacheDB()
 {
-	QFile cache("User/Music/cache.db");
+	QFile cache(getCacheLocation()+"/ppvs_cache.db");
 	cache.open(QIODevice::ReadOnly);
 	QDataStream dataStream(&cache);
 
@@ -113,7 +113,7 @@ void CacheDB::removeHashCode(unsigned hash)
 
 void CacheDB::write()
 {
-	QFile cache("User/Music/cache.db");
+	QFile cache(getCacheLocation()+"/ppvs_cache.db");
 	cache.open(QIODevice::WriteOnly);
 	QDataStream dataStream(&cache);
 

--- a/Client/pvsapplication.cpp
+++ b/Client/pvsapplication.cpp
@@ -14,13 +14,13 @@ struct PVSApplication::Priv {
 	MusicPlayer normalPlayer, feverPlayer;
 
 	Priv()
-		: normalPlaylist("User/Music/Normal.m3u")
-		, feverPlaylist("User/Music/Fever.m3u")
+		: normalPlaylist(getDataLocation()+"/User/Music/Normal.m3u")
+		, feverPlaylist(getDataLocation()+"/User/Music/Fever.m3u")
 		, normalPlayer(normalPlaylist)
 		, feverPlayer(feverPlaylist)
 	{
-		normalPlaylist.discover("User/Music/Normal");
-		feverPlaylist.discover("User/Music/Fever");
+		normalPlaylist.discover(getDataLocation()+"/User/Music/Normal");
+		feverPlaylist.discover(getDataLocation()+"/User/Music/Fever");
 	}
 };
 
@@ -28,20 +28,18 @@ PVSApplication::PVSApplication(int& argc, char** argv)
 	: QApplication(argc, argv)
 	, p(new Priv)
 {
+	// We do not need to check the existence of the folder, that's done automatically
 	// Copy settings.json if necessary
-	if (!QDir(getDataLocation()).exists()) {
-		QDir().mkpath(getDataLocation());
-	}
-	if (QFile("Settings.json").exists() && !QFile(getDataLocation() + "/Settings.json").exists()) {
-		QFile("Settings.json").copy(getDataLocation() + "/Settings.json");
+	if (QFile("Settings.json").exists() && !QFile(getSettingsLocation() + "/Settings.json").exists()) {
+		QFile("Settings.json").copy(getSettingsLocation() + "/Settings.json");
 	}
 
 	p->settings = new Settings(this);
 
 	// Make sure these exist.
-	QDir().mkdir("User/Music");
-	QDir().mkdir("User/Music/Fever");
-	QDir().mkdir("User/Music/Normal");
+	QDir().mkdir(getDataLocation()+"/User/Music");
+	QDir().mkdir(getDataLocation()+"/User/Music/Fever");
+	QDir().mkdir(getDataLocation()+"/User/Music/Normal");
 
 	pvsApp = this;
 

--- a/Puyolib/Game.cpp
+++ b/Puyolib/Game.cpp
@@ -1,6 +1,7 @@
 #include "Game.h"
 #include "../PVS_ENet/PVS_Channel.h"
 #include "../PVS_ENet/PVS_Client.h"
+#include <algorithm>
 #include <cstdio>
 #include <ctime>
 #include <fstream>


### PR DESCRIPTION
Until now we have been largely hard-coding the location of user files for PuyoVS. While this approach is okay it might turn back on us, especially when we account for modding support as we need to make sure that the user has access to the system assets at runtime, because otherwise we will not be able to store cached / permanently downloaded add-ons downloaded from within the game.

This is far from being complete, we need to thoroughly test that these folders are actually readable by the user and that we can go ahead without completely breaking the game and make the updater aware of the changes to prevent additional breakage.

PS: A bit controversial but I believe that on Windows we should just hide our assets in C:\\ProgramFiles as creating a root level folder seems extremely odd and bloaty.