### PR TITLE
Implement powershell build script

### DIFF
--- a/BuildScripts/WindowsPowershell/common_build_powershell.ps1
+++ b/BuildScripts/WindowsPowershell/common_build_powershell.ps1
@@ -87,9 +87,6 @@ pause
 ### Phase 6. Finalizing
 cls
 echo "Build finished. Cleaning up..."
-try {
-$GITHUB_PATH\.build\Client\RelWithDebInfo\PuyoVS.exe
-} catch {}
 del C:\qt -Recurse -Force
 del C:\qt.7z
 pause

--- a/BuildScripts/WindowsPowershell/common_build_powershell.ps1
+++ b/BuildScripts/WindowsPowershell/common_build_powershell.ps1
@@ -87,7 +87,7 @@ pause
 ### Phase 6. Finalizing
 cls
 echo "Build finished. Cleaning up..."
-explorer.exe --path "$GITHUB_PATH\.build\Client\RelWithDebInfo"
+$GITHUB_PATH\.build\Client\RelWithDebInfo\PuyoVS.exe
 del C:\qt -Recurse -Force
-del C:\qt.zip
+del C:\qt.7z
 pause

--- a/BuildScripts/WindowsPowershell/common_build_powershell.ps1
+++ b/BuildScripts/WindowsPowershell/common_build_powershell.ps1
@@ -28,8 +28,9 @@ if ( [IntPtr]::Size -eq 8 ) {
 }
 
 $GitHubPath = ($MyInvocation.MyCommand).Path
-for ($i = 0; $i -le 3; $i++) {
-	Split-Path $GitHubPath -Parent
+for ($i = 0; $i -le 2; $i++) {
+    $temp = Split-Path $GitHubPath
+    $GitHubPath = $temp
 }
 
 $QtPath = "C:\"

--- a/BuildScripts/WindowsPowershell/common_build_powershell.ps1
+++ b/BuildScripts/WindowsPowershell/common_build_powershell.ps1
@@ -1,0 +1,93 @@
+﻿echo "Puyo VS Build Script"
+echo ""
+echo "DO NOT USE THIS AS ARM64 BUILD: THE BUILD WILL CRASH!!!!!"
+echo ""
+echo ""
+
+## Tried to implement 7z auto-install, but I didn't.
+## If you want to implement that, you can.
+echo "Before start, you SHOULD install these programs manually."
+echo "If installed, press ENTER to continue."
+echo ""
+echo "Programs:"
+echo "  - Git"
+echo "  - 7z"
+echo "  - cmake"
+echo ""
+echo "Also, please run this script with Administrator privillige."
+## other programs are handlable through ps1 script
+pause
+echo ""
+
+if ( [IntPtr]::Size -eq 4 ) {
+    $SYSARCH = 'Win32'
+    $MATARCH = 'x86'
+}
+if ( [IntPtr]::Size -eq 8 ) {
+    $SYSARCH = 'x64'
+    $MATARCH = 'x64'
+}
+
+$GITHUB_PATH = "$env:USERPROFILE\GitHub\PuyoVS"
+del "$GITHUB_PATH" -Recurse -Force
+
+### Phase 1. Install winget if not installed
+###### (If just using Qt and cmake, this could be skipped)
+###### actually it foeces to download the latest one and force-install it
+echo "Downloading and installing winget..."
+## Download from aka.ms...
+Invoke-WebRequest -Uri "https://aka.ms/getwinget" -OutFile "$env:TEMP\PuyoVS_Build\winget.msixbundle"
+## Force-install... (If newer one installed, it'll be crashed with code 0)
+Add-AppPackage -path "$env:TEMP\PuyoVS_Build\winget.msixbundle"
+## ..and install VS 2022
+winget install Microsoft.VisualStudio.2022.Community --silent --override "--wait --quiet --add ProductLang En-us --add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended"
+
+### Phase 2. Download Qt SDK
+clear
+echo "Winget installed successfully."
+echo ""
+echo "Now this will download Qt SDK, required to build Puyo VS."
+## Download from GitHub...
+Invoke-WebRequest -Uri "https://github.com/puyonexus/qt-sdk-builder/releases/download/v2/qt-windows-5.15.2-$MATARCH-msvc-static-release.7z" -OutFile "C:\qt.7z"
+
+### Phase 3. Extract Qt SDK
+echo "Extracting..."
+echo "If error occurs, please install 7z and run the script from the beginning."
+## Use 7z to extract qt.7z
+7z x C:\qt.7z -oC:\Qt\
+## ..and add to path
+#### Quote: https://techexpert.tips/powershell/powershell-edit-path-variable/
+$TEMPQT = "C:\Qt\Qt-5.15.2\bin"
+$OLDPATH = [System.Environment]::GetEnvironmentVariable('PATH','machine')
+$NEWPATH = "$OLDPATH;$TEMP_CMAKE;$TEMPQT"
+[Environment]::SetEnvironmentVariable('PATH', "$NEWPATH", 'MACHINE')
+#### Cleanup
+$TEMPQT = ""
+$OLDPATH = ""
+$NEWPATH = ""
+
+### Phase 4. Git Clone
+clear
+echo "Now this will clone Puyo VS repository."
+echo "Ignore the git error."
+git clone --recursive "https://github.com/puyonexus/puyovs.git" "$GITHUB_PATH"
+cd "$GITHUB_PATH"
+
+### Phase 5. Make CMake Build Directory
+clear
+echo "Now this will configure PuyoVS via CMake."
+## Init CMake
+cmake -B .build
+## Build PuyoVS
+cmake --build .build --parallel 8 --config RelWithDebInfo
+## Install Assets
+cmake --install .build --config RelWithDebInfo
+pause
+
+### Phase 6. Finalizing
+cls
+echo "Build finished. Cleaning up..."
+explorer.exe --path "$GITHUB_PATH\.build\Client\RelWithDebInfo"
+del C:\qt -Recurse -Force
+del C:\qt.zip
+pause

--- a/BuildScripts/WindowsPowershell/common_build_powershell.ps1
+++ b/BuildScripts/WindowsPowershell/common_build_powershell.ps1
@@ -87,7 +87,9 @@ pause
 ### Phase 6. Finalizing
 cls
 echo "Build finished. Cleaning up..."
+try {
 $GITHUB_PATH\.build\Client\RelWithDebInfo\PuyoVS.exe
+} catch {}
 del C:\qt -Recurse -Force
 del C:\qt.7z
 pause

--- a/BuildScripts/WindowsPowershell/common_build_powershell.ps1
+++ b/BuildScripts/WindowsPowershell/common_build_powershell.ps1
@@ -1,4 +1,4 @@
-﻿echo "Puyo VS Build Script"
+echo "Puyo VS Build Script"
 echo ""
 echo "DO NOT USE THIS AS ARM64 BUILD: THE BUILD WILL CRASH!!!!!"
 echo ""
@@ -10,7 +10,6 @@ echo "Before start, you SHOULD install these programs manually."
 echo "If installed, press ENTER to continue."
 echo ""
 echo "Programs:"
-echo "  - Git"
 echo "  - 7z"
 echo "  - cmake"
 echo ""
@@ -28,65 +27,68 @@ if ( [IntPtr]::Size -eq 8 ) {
     $MATARCH = 'x64'
 }
 
-$GITHUB_PATH = "$env:USERPROFILE\GitHub\PuyoVS"
-del "$GITHUB_PATH" -Recurse -Force
+$GitHubPath = ($MyInvocation.MyCommand).Path
+for ($i = 0; $i -le 3; $i++) {
+	Split-Path $GitHubPath -Parent
+}
+
+$QtPath = "C:\"
 
 ### Phase 1. Install winget if not installed
-###### (If just using Qt and cmake, this could be skipped)
-###### actually it foeces to download the latest one and force-install it
 echo "Downloading and installing winget..."
 ## Download from aka.ms...
 Invoke-WebRequest -Uri "https://aka.ms/getwinget" -OutFile "$env:TEMP\PuyoVS_Build\winget.msixbundle"
 ## Force-install... (If newer one installed, it'll be crashed with code 0)
 Add-AppPackage -path "$env:TEMP\PuyoVS_Build\winget.msixbundle"
-## ..and install VS 2022
-winget install Microsoft.VisualStudio.2022.Community --silent --override "--wait --quiet --add ProductLang En-us --add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended"
+echo "Winget installed successfully."
+echo ""
+
+### Phase 1.1. Install Visual Studio BuildTools 2022
+## Install with winget...
+winget install Microsoft.VisualStudio.2022.BuildTools --silent --override "--wait --quiet --add ProductLang En-us --add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended"
 
 ### Phase 2. Download Qt SDK
 clear
-echo "Winget installed successfully."
+echo "Visual Studio BuildTools has been installed successfully."
 echo ""
 echo "Now this will download Qt SDK, required to build Puyo VS."
 ## Download from GitHub...
-Invoke-WebRequest -Uri "https://github.com/puyonexus/qt-sdk-builder/releases/download/v2/qt-windows-5.15.2-$MATARCH-msvc-static-release.7z" -OutFile "C:\qt.7z"
+Invoke-WebRequest -Uri "https://github.com/puyonexus/qt-sdk-builder/releases/download/v2/qt-windows-5.15.2-$MATARCH-msvc-static-release.7z" -OutFile "$QtPath\qt.7z"
 
 ### Phase 3. Extract Qt SDK
 echo "Extracting..."
 echo "If error occurs, please install 7z and run the script from the beginning."
 ## Use 7z to extract qt.7z
-7z x C:\qt.7z -oC:\Qt\
+7z x "$QtPath\qt.7z" -o"$QtPath\Qt\"
 ## ..and add to path
 #### Quote: https://techexpert.tips/powershell/powershell-edit-path-variable/
-$TEMPQT = "C:\Qt\Qt-5.15.2\bin"
+$TEMPQT = "$QtPath\Qt\Qt-5.15.2\bin"
 $OLDPATH = [System.Environment]::GetEnvironmentVariable('PATH','machine')
-$NEWPATH = "$OLDPATH;$TEMP_CMAKE;$TEMPQT"
+$NEWPATH = "$OLDPATH;$TEMPQT"
 [Environment]::SetEnvironmentVariable('PATH', "$NEWPATH", 'MACHINE')
 #### Cleanup
 $TEMPQT = ""
 $OLDPATH = ""
 $NEWPATH = ""
 
-### Phase 4. Git Clone
-clear
-echo "Now this will clone Puyo VS repository."
-echo "Ignore the git error."
-git clone --recursive "https://github.com/puyonexus/puyovs.git" "$GITHUB_PATH"
-cd "$GITHUB_PATH"
-
-### Phase 5. Make CMake Build Directory
+### Phase 4. Make CMake Build Directory
 clear
 echo "Now this will configure PuyoVS via CMake."
+## Relate 
+cd $GitHubPath
+mkdir .\.build
 ## Init CMake
 cmake -B .build
 ## Build PuyoVS
 cmake --build .build --parallel 8 --config RelWithDebInfo
 ## Install Assets
 cmake --install .build --config RelWithDebInfo
+echo "Build finished. Please check file at '$GitHubPath\.build\Client\RelWithDebInfo\PuyoVS.exe'."
 pause
 
 ### Phase 6. Finalizing
 cls
 echo "Build finished. Cleaning up..."
-del C:\qt -Recurse -Force
-del C:\qt.7z
+del "$QtPath\qt" -Recurse -Force
+del "$QtPath\qt.7z"
 pause

--- a/BuildScripts/WindowsPowershell/lightweight_build_powershell.ps1
+++ b/BuildScripts/WindowsPowershell/lightweight_build_powershell.ps1
@@ -1,0 +1,87 @@
+echo "Puyo VS Build Script"
+echo ""
+echo "DO NOT USE THIS AS ARM64 BUILD: THE BUILD WILL CRASH!!!!!"
+echo ""
+echo ""
+
+## Tried to implement 7z auto-install, but I didn't.
+## If you want to implement that, you can.
+echo "Before start, you SHOULD install these programs manually."
+echo "If installed, press ENTER to continue."
+echo ""
+echo "Programs:"
+echo "  - Git"
+echo "  - 7z"
+echo "  - CMake"
+echo "  - Also, you should have setted up VC++ build environment."
+echo "  If not, please use the common one."
+echo ""
+echo "Also, please run this script with Administrator privillige."
+## other programs are handlable through ps1 script
+pause
+echo ""
+
+## [IntPtr]::Size is 4 on x86 and 8 on x64/ARM64
+if ( [IntPtr]::Size -eq 4 ) {
+    $SYSARCH = 'Win32'
+    $MATARCH = 'x86'
+}
+if ( [IntPtr]::Size -eq 8 ) {
+    $SYSARCH = 'x64'
+    $MATARCH = 'x64'
+}
+
+$GITHUB_PATH = "$env:USERPROFILE\GitHub\PuyoVS"
+del "$GITHUB_PATH" -Recurse -Force
+
+### Phase 1. Install winget if not installed
+## This phase is skipped since it's lightweight:
+## the lightweight build script is used if you have installed Visual C++ build environment.
+
+### Phase 2. Download Qt SDK
+clear
+echo "Now this will download Qt SDK, required to build Puyo VS."
+## Download from GitHub...
+Invoke-WebRequest -Uri "https://github.com/puyonexus/qt-sdk-builder/releases/download/v2/qt-windows-5.15.2-$MATARCH-msvc-static-release.7z" -OutFile "C:\qt.7z"
+
+### Phase 3. Extract Qt SDK
+echo "Extracting..."
+echo "If error occurs, please install 7z and run the script from the beginning."
+## Use 7z to extract qt.7z
+7z x C:\qt.7z -oC:\Qt\
+## ..and add to path
+#### Quote: https://techexpert.tips/powershell/powershell-edit-path-variable/
+$TEMPQT = "C:\Qt\Qt-5.15.2\bin"
+$OLDPATH = [System.Environment]::GetEnvironmentVariable('PATH','machine')
+$NEWPATH = "$OLDPATH;$TEMP_CMAKE;$TEMPQT"
+[Environment]::SetEnvironmentVariable('PATH', "$NEWPATH", 'MACHINE')
+#### Cleanup
+$TEMPQT = ""
+$OLDPATH = ""
+$NEWPATH = ""
+
+### Phase 4. Git Clone
+clear
+echo "Now this will clone Puyo VS repository."
+echo "Ignore the git error."
+git clone --recursive "https://github.com/puyonexus/puyovs.git" "$GITHUB_PATH"
+cd "$GITHUB_PATH"
+
+### Phase 5. Make CMake Build Directory
+clear
+echo "Now this will configure PuyoVS via CMake."
+## Init CMake
+cmake -B .build
+## Build PuyoVS
+cmake --build .build --parallel 8 --config RelWithDebInfo
+## Install Assets
+cmake --install .build --config RelWithDebInfo
+pause
+
+### Phase 6. Finalizing
+cls
+echo "Build finished. Cleaning up..."
+$GITHUB_PATH\.build\Client\RelWithDebInfo\PuyoVS.exe
+del C:\qt -Recurse -Force
+del C:\qt.7z
+pause

--- a/BuildScripts/WindowsPowershell/lightweight_build_powershell.ps1
+++ b/BuildScripts/WindowsPowershell/lightweight_build_powershell.ps1
@@ -81,7 +81,9 @@ pause
 ### Phase 6. Finalizing
 cls
 echo "Build finished. Cleaning up..."
+try {
 $GITHUB_PATH\.build\Client\RelWithDebInfo\PuyoVS.exe
+} catch {}
 del C:\qt -Recurse -Force
 del C:\qt.7z
 pause

--- a/BuildScripts/WindowsPowershell/lightweight_build_powershell.ps1
+++ b/BuildScripts/WindowsPowershell/lightweight_build_powershell.ps1
@@ -81,9 +81,6 @@ pause
 ### Phase 6. Finalizing
 cls
 echo "Build finished. Cleaning up..."
-try {
-$GITHUB_PATH\.build\Client\RelWithDebInfo\PuyoVS.exe
-} catch {}
 del C:\qt -Recurse -Force
 del C:\qt.7z
 pause

--- a/BuildScripts/WindowsPowershell/lightweight_build_powershell.ps1
+++ b/BuildScripts/WindowsPowershell/lightweight_build_powershell.ps1
@@ -29,8 +29,9 @@ if ( [IntPtr]::Size -eq 8 ) {
 }
 
 $GitHubPath = ($MyInvocation.MyCommand).Path
-for ($i = 0; $i -le 3; $i++) {
-	Split-Path $GitHubPath -Parent
+for ($i = 0; $i -le 2; $i++) {
+	$temp = Split-Path $GitHubPath
+    $GitHubPath = $temp
 }
 
 $QtPath = "C:\"
@@ -39,8 +40,6 @@ $QtPath = "C:\"
 
 ### Phase 2. Download Qt SDK
 clear
-echo "Visual Studio BuildTools has been installed successfully."
-echo ""
 echo "Now this will download Qt SDK, required to build Puyo VS."
 ## Download from GitHub...
 Invoke-WebRequest -Uri "https://github.com/puyonexus/qt-sdk-builder/releases/download/v2/qt-windows-5.15.2-$MATARCH-msvc-static-release.7z" -OutFile "$QtPath\qt.7z"


### PR DESCRIPTION
Tested on Windows 11 Home, and it DOES WORK.
(Manually installing 7z, Git, and CMake is required.)

- `.\BuildScripts\WindowsPowershell\common_build_powershell.ps1`: Common build script  
You can use this as default.
- `.\BuildScripts\WindowsPowershell\lightweight_build_powershell.ps1`: Minimum build script
You can use this when your environment is already set up.

Code from:
- GitHub Actions
- README.md -> Setup VS 2022 & Build using the Command Line