### PR TITLE
WIP: Puyolib refactor

### DIFF
--- a/Puyolib/CMakeLists.txt
+++ b/Puyolib/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(Puyolib
     RNG/LegacyPuyoRng.cpp
     RNG/MersenneTwister.cpp
     RNG/PuyoRng.cpp
-)
+        GameRenderer.cpp GameRenderer.h)
 
 target_compile_features(Puyolib PUBLIC cxx_std_17)
 

--- a/Puyolib/CMakeLists.txt
+++ b/Puyolib/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(Puyolib
     global.cpp
     GameSettings.cpp
     Game.cpp
+    GameRenderer.cpp
     Field.cpp
     FeverCounter.cpp
     DropPattern.cpp
@@ -29,8 +30,7 @@ add_library(Puyolib
     RNG/ClassicRng.cpp
     RNG/LegacyPuyoRng.cpp
     RNG/MersenneTwister.cpp
-    RNG/PuyoRng.cpp
-        GameRenderer.cpp GameRenderer.h)
+    RNG/PuyoRng.cpp)
 
 target_compile_features(Puyolib PUBLIC cxx_std_17)
 

--- a/Puyolib/CharacterSelect.cpp
+++ b/Puyolib/CharacterSelect.cpp
@@ -23,12 +23,12 @@ CharacterSelect::CharacterSelect(Game* g)
 	for (int i = 0; i < height; i++) {
 		constexpr int width = 8;
 		for (int j = 0; j < width; j++) {
-			m_holder[i * width + j].setImage(g->m_data->imgCharHolder);
+			m_holder[i * width + j].setImage(m_data->imgCharHolder);
 			m_holder[i * width + j].setCenter(0, 0);
 			m_holder[i * width + j].setPosition(
 				static_cast<float>(64 + j * 66),
 				static_cast<float>(64 + i * 52));
-			m_charSprite[i * width + j].setImage(g->m_data->front->loadImage(m_currentGame->m_baseAssetDir + kFolderUserCharacter + m_currentGame->m_settings->characterSetup[m_order[i * width + j]] + "/icon.png"));
+			m_charSprite[i * width + j].setImage(m_data->front->loadImage(m_currentGame->m_baseAssetDir + kFolderUserCharacter + m_currentGame->m_settings->characterSetup[m_order[i * width + j]] + "/icon.png"));
 			m_charSprite[i * width + j].setCenter(0, 0);
 			m_charSprite[i * width + j].setPosition(
 				static_cast<float>(64 + j * 66 + 1),

--- a/Puyolib/CharacterSelect.cpp
+++ b/Puyolib/CharacterSelect.cpp
@@ -447,7 +447,7 @@ void CharacterSelect::end()
 				for (size_t i = 0; i < numPlayers; i++) {
 					m_currentGame->m_players[i]->m_currentPhase = Phase::GETREADY;
 				}
-				m_currentGame->m_readyGoObj.prepareAnimation("readygo");
+				m_currentGame->m_gameRenderer->m_readyGoObj.prepareAnimation("readygo");
 				m_data->matchTimer = 0;
 			}
 			m_currentGame->m_menuSelect = 0;

--- a/Puyolib/CharacterSelect.cpp
+++ b/Puyolib/CharacterSelect.cpp
@@ -12,7 +12,7 @@ namespace ppvs {
 CharacterSelect::CharacterSelect(Game* g)
 {
 	m_currentGame = g;
-	m_data = g->m_data;
+	m_data = g->m_gameRenderer->m_gameData;
 
 	m_background.setImage(nullptr);
 	m_background.setScale(2.f * 640.f, 480.f);

--- a/Puyolib/Game.cpp
+++ b/Puyolib/Game.cpp
@@ -469,76 +469,12 @@ void Game::playGame()
 
 void Game::renderGame()
 {
-	// Tunnel shader
-	if (m_gameRenderer->m_gameData->tunnelShader) {
-		m_gameRenderer->m_gameData->tunnelShader->setParameter("time", static_cast<double>(m_gameRenderer->m_gameData->globalTimer) / 60.0);
-	}
-
-	// Clear screen
-	m_gameRenderer->m_gameData->front->clear();
-
-	// Draw background
-	m_gameRenderer->m_backgroundSprite.draw(m_gameRenderer->m_gameData->front);
-	//m_spriteBackground.draw(m_gameRenderer->m_gameData->front);
-	m_gameRenderer->m_backgroundAnimation.draw();
-	//m_backgroundAnimation.draw();
-
-	// Draw timer
-	if (m_currentGameStatus == GameStatus::IDLE && !m_settings->useCpuPlayers && (countActivePlayers() > 1 || m_settings->rankedMatch)) {
-		m_timerSprite[0].draw(m_gameRenderer->m_gameData->front);
-		m_timerSprite[1].draw(m_gameRenderer->m_gameData->front);
-	}
-	if (m_players[0]->getPlayerType() == HUMAN && m_players[0]->m_currentPhase == Phase::PICKCOLORS
-		&& !m_settings->useCpuPlayers && !m_players[0]->m_pickedColor) {
-		m_timerSprite[0].draw(m_gameRenderer->m_gameData->front);
-		m_timerSprite[1].draw(m_gameRenderer->m_gameData->front);
-	}
-
-	// Draw player related objects
-	for (const auto& player : m_players) {
-		// Draw fields
-		player->draw();
-	}
-	for (const auto& player : m_players) {
-		// Draw light effect
-		player->drawEffect();
-	}
-	if (!m_players.empty()) {
-		// Needs at least 1 player to draw ready-go
-		m_gameRenderer->m_readyGoObj.draw();
-	}
-
-	// Draw menuSelects
-	if (m_menuSelect == 1) {
-		m_gameRenderer->m_charSelectMenu->draw();
-	}
-	if (m_menuSelect == 2) {
-		m_gameRenderer->m_mainMenu->draw();
-	}
-
-	// Darken screen
-	if (m_rankedState >= 3) {
-		m_gameRenderer->m_black.draw(m_gameRenderer->m_gameData->front);
-		// Draw status text
-		if (m_statusText) {
-			m_gameRenderer->m_gameData->front->setColor(255, 255, 255, 255);
-			m_statusText->draw(8, 0);
-		}
-	}
-
-	m_gameRenderer->m_gameData->front->swapBuffers();
+	m_gameRenderer->renderGame();
 }
 
 void Game::setStatusText(const char* utf8)
 {
-	if (utf8 == m_lastText)
-		return;
-	if (!m_statusFont)
-		return;
-	delete m_statusText;
-
-	m_statusText = m_statusFont->render(utf8);
-	m_lastText = utf8;
+	m_gameRenderer->setStatusText(utf8);
 }
 
 void Game::setWindowFocus(bool focus) const

--- a/Puyolib/Game.cpp
+++ b/Puyolib/Game.cpp
@@ -37,6 +37,8 @@ Game::Game(GameSettings* gs)
 
 	m_statusFont = nullptr;
 	m_statusText = nullptr;
+
+	m_gameRenderer = new GameRenderer(this);
 }
 
 Game::~Game()
@@ -49,13 +51,16 @@ Game::~Game()
 
 	// Delete associated global properties
 	delete m_settings;
+
+	delete m_gameRenderer;
+
 	delete m_charSelectMenu;
 	delete m_mainMenu;
 	delete m_currentRuleSet;
-	delete m_statusText;
+	/*delete m_statusText;
 	delete m_statusFont;
 	delete m_data->front;
-	delete m_data;
+	delete m_data;*/
 }
 
 void Game::close()

--- a/Puyolib/Game.cpp
+++ b/Puyolib/Game.cpp
@@ -278,10 +278,7 @@ int Game::getActivePlayers() const
 
 void Game::initGame(Frontend* f)
 {
-	m_data = new GameData;
-	m_data->front = f;
-
-	loadGlobal();
+	m_gameRenderer->initRenderer(f);
 
 	// Set random seed
 	m_randomSeedNextList = getRandom(100000);

--- a/Puyolib/Game.cpp
+++ b/Puyolib/Game.cpp
@@ -29,12 +29,6 @@ Game::Game(GameSettings* gs)
 	activeGame = this;
 	m_choiceTimer = (gs->rankedMatch == true ? 5 : 30) * 60;
 
-	m_black.setImage(nullptr);
-	m_black.setScale(640 * 2, 480);
-	m_black.setColor(0, 0, 0);
-	m_black.setTransparency(0.5f);
-	m_black.setPosition(-640.f / 2.f, -480.f / 4.f);
-
 	m_statusFont = nullptr;
 	m_statusText = nullptr;
 
@@ -55,185 +49,12 @@ Game::~Game()
 	delete m_gameRenderer;
 
 	delete m_currentRuleSet;
-	/*delete m_statusText;
-	delete m_statusFont;
-	delete m_data->front;
-	delete m_data;*/
 }
 
 void Game::close()
 {
 	// Close game
 	m_runGame = false;
-}
-
-void Game::loadGlobal()
-{
-	// Load user settings
-	m_baseAssetDir = m_settings->baseAssetDir;
-	m_data->gUserSettings.backgroundDirPath = m_settings->background;
-	m_data->gUserSettings.puyoDirPath = m_settings->puyo;
-	m_data->gUserSettings.sfxDirPath = m_settings->sfx;
-
-	// Set global images
-	loadImages();
-
-	// Load all sounds
-	loadSounds();
-
-	// Init shaders
-	m_data->glowShader = nullptr;
-	m_data->tunnelShader = nullptr;
-
-	if (useShaders) {
-		// https://stackoverflow.com/a/33172917
-		static auto glowShaderSource =
-#include "glowShader.vs"
-			;
-
-		m_data->glowShader = m_data->front->loadShader(glowShaderSource);
-		if (m_data->glowShader) {
-			m_data->glowShader->setCurrentTexture("tex");
-			m_data->glowShader->setParameter("color", 1.0);
-		}
-
-		static auto tunnelShaderSource =
-#include "tunnelShader.vs"
-			;
-		m_data->tunnelShader = m_data->front->loadShader(tunnelShaderSource);
-		if (m_data->tunnelShader) {
-			m_data->tunnelShader->setCurrentTexture("tex");
-			m_data->tunnelShader->setParameter("time", 1.0);
-			m_data->tunnelShader->setParameter("cl", 0.0, 0.0, 1.0, 1.0);
-		}
-	}
-
-	// Other
-	m_data->globalTimer = 0;
-	m_data->windowFocus = true;
-	m_data->playSounds = m_settings->playSound;
-	m_data->playMusic = m_settings->playMusic;
-
-	m_statusFont = m_data->front->loadFont("Arial", 14);
-	setStatusText("");
-}
-
-void Game::loadSounds() const
-{
-	Sounds& snd = m_data->snd;
-	setBuffer(snd.chain[0], (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/chain1.ogg"))));
-	setBuffer(snd.chain[1], (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/chain2.ogg"))));
-	setBuffer(snd.chain[2], (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/chain3.ogg"))));
-	setBuffer(snd.chain[3], (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/chain4.ogg"))));
-	setBuffer(snd.chain[4], (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/chain5.ogg"))));
-	setBuffer(snd.chain[5], (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/chain6.ogg"))));
-	setBuffer(snd.chain[6], (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/chain7.ogg"))));
-	setBuffer(snd.allClearDrop, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/allclear.ogg"))));
-	setBuffer(snd.drop, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/drop.ogg"))));
-	setBuffer(snd.fever, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/fever.ogg"))));
-	setBuffer(snd.feverLight, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/feverlight.ogg"))));
-	setBuffer(snd.feverTimeCount, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/fevertimecount.ogg"))));
-	setBuffer(snd.feverTimeEnd, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/fevertimeend.ogg"))));
-	setBuffer(snd.go, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/go.ogg"))));
-	setBuffer(snd.heavy, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/heavy.ogg"))));
-	setBuffer(snd.hit, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/hit.ogg"))));
-	setBuffer(snd.lose, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/lose.ogg"))));
-	setBuffer(snd.move, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/move.ogg"))));
-	setBuffer(snd.nuisanceHitL, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/nuisance_hitL.ogg"))));
-	setBuffer(snd.nuisanceHitM, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/nuisance_hitM.ogg"))));
-	setBuffer(snd.nuisanceHitS, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/nuisance_hitS.ogg"))));
-	setBuffer(snd.nuisanceL, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/nuisanceL.ogg"))));
-	setBuffer(snd.nuisanceS, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/nuisanceS.ogg"))));
-	setBuffer(snd.ready, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/ready.ogg"))));
-	setBuffer(snd.rotate, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/rotate.ogg"))));
-	setBuffer(snd.win, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/win.ogg"))));
-	setBuffer(snd.decide, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/decide.ogg"))));
-	setBuffer(snd.cancel, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/cancel.ogg"))));
-	setBuffer(snd.cursor, (m_data->front->loadSound(kFolderUserSounds + m_data->gUserSettings.sfxDirPath + std::string("/cursor.ogg"))));
-}
-
-// Load images (user defined)
-void Game::loadImages() const
-{
-	// Load puyo
-	m_data->imgPuyo = m_data->front->loadImage(m_baseAssetDir + kFolderUserPuyo + m_data->gUserSettings.puyoDirPath + std::string(".png"));
-
-	// Check rotation center of quadruplet
-	if (m_data->imgPuyo && !m_data->imgPuyo->error() && m_data->imgPuyo->height() > 10) {
-		for (int i = 0; i < kPuyoX; i++) {
-			if (m_data->imgPuyo->pixel(11 * kPuyoX - i, 14 * kPuyoY).a > 50) {
-				m_data->quadrupletCenter = kPuyoX - i;
-				break;
-			}
-		}
-	}
-	m_data->imgPuyo->setFilter(FilterType::LinearFilter);
-
-	// Lights
-	m_data->imgLight = m_data->front->loadImage(m_baseAssetDir + "Data/Light.png");
-	m_data->imgLightS = m_data->front->loadImage(m_baseAssetDir + "Data/Light_s.png");
-	m_data->imgLightHit = m_data->front->loadImage(m_baseAssetDir + "Data/Light_hit.png");
-	m_data->imgFSparkle = m_data->front->loadImage(m_baseAssetDir + "Data/CharSelect/fsparkle.png");
-	m_data->imgFLight = m_data->front->loadImage(m_baseAssetDir + "Data/fLight.png");
-	m_data->imgFLightHit = m_data->front->loadImage(m_baseAssetDir + "Data/fLight_hit.png");
-
-	m_data->imgTime = m_data->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + std::string("/time.png"));
-
-	// Menu
-	for (int i = 0; i < 3; ++i) {
-		for (int j = 0; j < 2; ++j) {
-			// Safe (because i/j have defined ranges)
-			char buffer[128];
-			sprintf(buffer, "Data/Menu/menu%i%i.png", i, j);
-			m_data->imgMenu[i][j] = m_data->front->loadImage(m_baseAssetDir + buffer);
-		}
-	}
-
-	// Backgrounds
-	m_data->imgBackground = m_data->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + std::string("/back.png"));
-	m_data->imgFieldFever = m_data->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + std::string("/ffield.png"));
-
-	// Background of next puyo
-	m_data->imgNextPuyoBackgroundR = m_data->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + std::string("/nextR.png"));
-	m_data->imgNextPuyoBackgroundL = m_data->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + std::string("/nextL.png"));
-
-	if (!useShaders) {
-		for (int i = 0; i < 30; ++i) {
-			m_data->imgFeverBack[i] = m_data->front->loadImage(m_baseAssetDir + std::string("Data/Fever/f" + toString(i) + ".png").c_str());
-		}
-	}
-
-	// Load default fields. Custom fields should be loaded per character
-	m_data->imgField1 = m_data->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + std::string("/field1.png"));
-	m_data->imgField2 = m_data->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + std::string("/field2.png"));
-	m_data->imgBorder1 = m_data->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + std::string("/border1.png"));
-	m_data->imgBorder2 = m_data->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + std::string("/border2.png"));
-	m_data->imgPlayerBorder = m_data->front->loadImage(m_baseAssetDir + "Data/border.png");
-	m_data->imgSpice = m_data->front->loadImage(m_baseAssetDir + "Data/spice.png");
-
-	// Other
-	m_data->imgScore = m_data->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + std::string("/score.png"));
-	m_data->imgAllClear = m_data->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + std::string("/allclear.png"));
-	m_data->imgLose = m_data->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + std::string("/lose.png"));
-	m_data->imgWin = m_data->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + std::string("/win.png"));
-	m_data->imgFeverGauge = m_data->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + std::string("/fgauge.png"));
-	m_data->imgSeconds = m_data->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + std::string("/fcounter.png"));
-	m_data->imgCharHolder = m_data->front->loadImage(m_baseAssetDir + "Data/CharSelect/charHolder.png");
-	m_data->imgNameHolder = m_data->front->loadImage(m_baseAssetDir + "Data/CharSelect/nameHolder.png");
-	m_data->imgBlack = m_data->front->loadImage(m_baseAssetDir + "Data/CharSelect/black.png");
-	m_data->imgDropSet = m_data->front->loadImage(m_baseAssetDir + "Data/CharSelect/dropset.png");
-	m_data->imgChain = m_data->front->loadImage(m_baseAssetDir + std::string("User/Backgrounds/") + m_data->gUserSettings.backgroundDirPath + std::string("/chain.png"));
-	m_data->imgCheckMark = m_data->front->loadImage(m_baseAssetDir + "Data/checkmark.png");
-	m_data->imgPlayerCharSelect = m_data->front->loadImage(m_baseAssetDir + "Data/CharSelect/charSelect.png");
-
-	for (int i = 0; i < kNumCharacters; ++i) {
-		m_data->imgCharField[i] = m_data->front->loadImage(m_baseAssetDir + kFolderUserCharacter + m_settings->characterSetup[static_cast<PuyoCharacter>(i)] + "/field.png");
-		m_data->imgCharSelect[i] = m_data->front->loadImage(m_baseAssetDir + kFolderUserCharacter + m_settings->characterSetup[static_cast<PuyoCharacter>(i)] + "/select.png");
-		m_data->imgCharName[i] = m_data->front->loadImage(m_baseAssetDir + kFolderUserCharacter + m_settings->characterSetup[static_cast<PuyoCharacter>(i)] + "/name.png");
-		m_data->imgSelect[i] = m_data->front->loadImage(m_baseAssetDir + kFolderUserCharacter + m_settings->characterSetup[static_cast<PuyoCharacter>(i)] + "/select.png");
-	}
-
-	m_data->imgPlayerNumber = m_data->front->loadImage(m_baseAssetDir + "Data/CharSelect/playernumber.png");
 }
 
 void Game::initPlayers()
@@ -297,25 +118,6 @@ void Game::initGame(Frontend* f)
 		m_menuSelect = static_cast<int>(m_settings->startWithCharacterSelect);
 	}
 	m_timerEndMatch = 0;
-
-	// Initialize readygo animation
-	m_readyGoObj.init(m_data, PosVectorFloat(320, 240), 1, m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + "/Animation/", "ready.xml", 3 * 60);
-	m_backgroundAnimation.init(m_data, PosVectorFloat(320, 240), 1, m_baseAssetDir + kFolderUserBackgrounds + m_data->gUserSettings.backgroundDirPath + "/Animation/", "animation.xml", 30 * 60);
-	m_backgroundAnimation.prepareAnimation("background");
-
-	// Other stuff
-	m_charSelectMenu = new CharacterSelect(this);
-	m_charSelectMenu->prepare();
-	m_mainMenu = new Menu(this);
-
-	m_timerSprite[0].setImage(m_data->imgPlayerNumber);
-	m_timerSprite[1].setImage(m_data->imgPlayerNumber);
-	m_timerSprite[0].setSubRect(0 / 10 * 24, 0, 0, 32);
-	m_timerSprite[1].setSubRect(0 / 10 * 24, 0, 0, 32);
-	m_timerSprite[0].setCenterBottom();
-	m_timerSprite[1].setCenterBottom();
-	m_timerSprite[0].setPosition(640 - 24, 32);
-	m_timerSprite[1].setPosition(640 - 24 - 24, 32);
 }
 
 // Set rules from RuleSetInfo.
@@ -529,7 +331,7 @@ void Game::playGame()
 
 	// Ready go
 	if (!m_players.empty()) {
-		m_readyGoObj.playAnimation();
+		m_gameRenderer->m_readyGoObj.playAnimation();
 	}
 	m_backgroundAnimation.playAnimation();
 
@@ -676,8 +478,10 @@ void Game::renderGame()
 	m_gameRenderer->m_gameData->front->clear();
 
 	// Draw background
-	m_spriteBackground.draw(m_gameRenderer->m_gameData->front);
-	m_backgroundAnimation.draw();
+	m_gameRenderer->m_backgroundSprite.draw(m_gameRenderer->m_gameData->front);
+	//m_spriteBackground.draw(m_gameRenderer->m_gameData->front);
+	m_gameRenderer->m_backgroundAnimation.draw();
+	//m_backgroundAnimation.draw();
 
 	// Draw timer
 	if (m_currentGameStatus == GameStatus::IDLE && !m_settings->useCpuPlayers && (countActivePlayers() > 1 || m_settings->rankedMatch)) {
@@ -701,7 +505,7 @@ void Game::renderGame()
 	}
 	if (!m_players.empty()) {
 		// Needs at least 1 player to draw ready-go
-		m_readyGoObj.draw();
+		m_gameRenderer->m_readyGoObj.draw();
 	}
 
 	// Draw menuSelects
@@ -714,7 +518,7 @@ void Game::renderGame()
 
 	// Darken screen
 	if (m_rankedState >= 3) {
-		m_black.draw(m_gameRenderer->m_gameData->front);
+		m_gameRenderer->m_black.draw(m_gameRenderer->m_gameData->front);
 		// Draw status text
 		if (m_statusText) {
 			m_gameRenderer->m_gameData->front->setColor(255, 255, 255, 255);

--- a/Puyolib/Game.cpp
+++ b/Puyolib/Game.cpp
@@ -83,12 +83,10 @@ void Game::loadGlobal()
 	m_data->tunnelShader = nullptr;
 
 	if (useShaders) {
-		static auto glowShaderSource = "uniform sampler2D tex;"
-									   "uniform float color;"
-									   "void main()"
-									   "{"
-									   "   gl_FragColor=texture2D(tex,gl_TexCoord[0].xy)+vec4(color,color,color,0);"
-									   "}";
+		// https://stackoverflow.com/a/33172917
+		static auto glowShaderSource =
+#include "glowShader.vs"
+			;
 
 		m_data->glowShader = m_data->front->loadShader(glowShaderSource);
 		if (m_data->glowShader) {
@@ -96,24 +94,9 @@ void Game::loadGlobal()
 			m_data->glowShader->setParameter("color", 1.0);
 		}
 
-		static auto tunnelShaderSource = "uniform vec4 cl;"
-										 "uniform float time;"
-										 "uniform sampler2D tex;"
-										 "void main(void) {"
-										 "   vec2 ccord = gl_TexCoord[0].xy;"
-										 "   vec2 pcord;"
-										 "   vec2 final;"
-										 "   float zoomspeed=0.5;"
-										 "   float rotatespeed=0.25;"
-										 "   ccord.x = step(0.5,ccord.y)*(-1.0+ 2.0*ccord.x)-(1.0-step(0.5,ccord.y))*(-1.0+ 2.0*ccord.x);"
-										 "   ccord.y = step(0.5,ccord.y)*(-1.0+ 2.0*ccord.y)-(1.0-step(0.5,ccord.y))*(-1.0+ 2.0*ccord.y);"
-										 "   pcord.x = 0.1/sqrt(ccord.x*ccord.x+ccord.y*ccord.y);pcord.y = atan(ccord.y,ccord.x)/3.141592;"
-										 "   final.x = step(0.25,pcord.x)*mod(pcord.x+zoomspeed*time,0.5)+(1.0-step(0.25,pcord.x))*mod(pcord.x+zoomspeed*time,0.5);"
-										 "   final.y = step(0.25,pcord.y)*mod(pcord.y+rotatespeed*time,0.5)+(1.0-step(0.25,pcord.y))*mod(pcord.y+rotatespeed*time,0.5);"
-										 "   vec3 col = texture2D(tex,final).xyz;"
-										 "   gl_FragColor = vec4(max(col/((pcord/0.1).x),0.1), 1.0) * cl;"
-										 "}";
-
+		static auto tunnelShaderSource =
+#include "tunnelShader.vs"
+			;
 		m_data->tunnelShader = m_data->front->loadShader(tunnelShaderSource);
 		if (m_data->tunnelShader) {
 			m_data->tunnelShader->setCurrentTexture("tex");

--- a/Puyolib/Game.h
+++ b/Puyolib/Game.h
@@ -9,6 +9,7 @@
 #include "RuleSet/RuleSet.h"
 #include "Sprite.h"
 #include "global.h"
+#include "GameRenderer.h"
 #include <iostream>
 #include <string>
 
@@ -50,6 +51,7 @@ struct NetworkMessage {
 };
 
 class Frontend;
+class GameRenderer;
 
 class Game {
 public:
@@ -97,6 +99,9 @@ public:
 	int m_activeAtStart = 0;
 
 	// Public variables
+
+
+	GameRenderer* m_gameRenderer;
 	int m_menuSelect = 0;
 	Animation m_readyGoObj {};
 	Animation m_backgroundAnimation {};

--- a/Puyolib/GameRenderer.cpp
+++ b/Puyolib/GameRenderer.cpp
@@ -1,8 +1,200 @@
-//
-// Created by krab on 24.6.23.
-//
+// Copyright (c) 2023, LossRain
+// SPDX-License-Identifier: GPLv3
 
 #include "GameRenderer.h"
+#include "global.h"
 
 namespace ppvs {
+GameRenderer::GameRenderer(ppvs::Game* game)
+	: m_game(game)
+{
+}
+
+GameRenderer::~GameRenderer()
+{
+	delete m_statusText;
+	delete m_statusFont;
+	delete m_gameData->front;
+	delete m_gameData;
+}
+
+void GameRenderer::initRenderer(Frontend* f)
+{
+	m_gameData = new GameData;
+	m_gameData->front = f;
+
+	// loadGlobal()
+	m_baseAssetDir = m_game->m_settings->baseAssetDir;
+	m_gameData->gUserSettings.backgroundDirPath = m_game->m_settings->background;
+	m_gameData->gUserSettings.puyoDirPath = m_game->m_settings->puyo;
+	m_gameData->gUserSettings.sfxDirPath = m_game->m_settings->sfx;
+
+	loadImages();
+
+	loadAudio();
+
+	if (useShaders) {
+		// https://stackoverflow.com/a/33172917
+		static auto glowShaderSource =
+#include "glowShader.vs"
+			;
+
+		m_gameData->glowShader = m_gameData->front->loadShader(glowShaderSource);
+		if (m_gameData->glowShader) {
+			m_gameData->glowShader->setCurrentTexture("tex");
+			m_gameData->glowShader->setParameter("color", 1.0);
+		}
+
+		static auto tunnelShaderSource =
+#include "tunnelShader.vs"
+			;
+		m_gameData->tunnelShader = m_gameData->front->loadShader(tunnelShaderSource);
+		if (m_gameData->tunnelShader) {
+			m_gameData->tunnelShader->setCurrentTexture("tex");
+			m_gameData->tunnelShader->setParameter("time", 1.0);
+			m_gameData->tunnelShader->setParameter("cl", 0.0, 0.0, 1.0, 1.0);
+		}
+	}
+
+	m_gameData->globalTimer = 0;
+	m_gameData->windowFocus = true;
+	m_gameData->playSounds = m_game->m_settings->playSound;
+	m_gameData->playMusic = m_game->m_settings->playMusic;
+
+	m_statusFont = m_gameData->front->loadFont("Arial", 14);
+	setStatusText("");
+}
+
+void GameRenderer::setStatusText(const char* utf8)
+{
+	if (utf8 != m_lastText && m_statusFont) {
+		delete m_statusText;
+
+		m_statusText = m_statusFont->render(utf8);
+		m_lastText = utf8;
+	}
+}
+
+void GameRenderer::loadImages() const
+{
+	// Load Puyo sheet
+	m_gameData->imgPuyo = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserPuyo + m_gameData->gUserSettings.puyoDirPath + std::string(".png"));
+
+	// Check rotation center of quadruplet
+	if (m_gameData->imgPuyo && !m_gameData->imgPuyo->error() && m_gameData->imgPuyo->height() > 10) {
+		for (int i = 0; i < kPuyoX; i++) {
+			if (m_gameData->imgPuyo->pixel(11 * kPuyoX - i, 14 * kPuyoY).a > 50) {
+				m_gameData->quadrupletCenter = kPuyoX - i;
+				break;
+			}
+		}
+	}
+	m_gameData->imgPuyo->setFilter(FilterType::LinearFilter);
+
+	// Light images
+	m_gameData->imgLight = m_gameData->front->loadImage(m_baseAssetDir + "Data/Light.png");
+	m_gameData->imgLightS = m_gameData->front->loadImage(m_baseAssetDir + "Data/Light_s.png");
+	m_gameData->imgLightHit = m_gameData->front->loadImage(m_baseAssetDir + "Data/Light_hit.png");
+	m_gameData->imgFSparkle = m_gameData->front->loadImage(m_baseAssetDir + "Data/CharSelect/fsparkle.png");
+	m_gameData->imgFLight = m_gameData->front->loadImage(m_baseAssetDir + "Data/fLight.png");
+	m_gameData->imgFLightHit = m_gameData->front->loadImage(m_baseAssetDir + "Data/fLight_hit.png");
+
+	m_gameData->imgTime = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + std::string("/time.png"));
+
+	// Menu
+	for (int i = 0; i < 3; ++i) {
+		for (int j = 0; j < 2; ++j) {
+			// Safe (because i/j have defined ranges) BUT WHY?
+
+			m_gameData->imgMenu[i][j] = m_gameData->front->loadImage(m_baseAssetDir + std::string("Data/Menu/menu"+toString(i)+toString(j)+".png"));
+			/*
+			char buffer[128];
+			sprintf(buffer, "Data/Menu/menu%i%i.png", i, j);
+			m_gameData->imgMenu[i][j] = m_gameData->front->loadImage(m_baseAssetDir + buffer);*/
+		}
+	}
+
+	// Backgrounds
+	m_gameData->imgBackground = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + std::string("/back.png"));
+	m_gameData->imgFieldFever = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + std::string("/ffield.png"));
+
+	// Background of next puyo
+	m_gameData->imgNextPuyoBackgroundR = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + std::string("/nextR.png"));
+	m_gameData->imgNextPuyoBackgroundL = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + std::string("/nextL.png"));
+
+	if (!useShaders) {
+		for (int i = 0; i < 30; ++i) {
+			m_gameData->imgFeverBack[i] = m_gameData->front->loadImage(m_baseAssetDir + std::string("Data/Fever/f" + toString(i) + ".png"));
+		}
+	}
+
+	// Load default fields. Custom fields should be loaded per character
+	m_gameData->imgField1 = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + std::string("/field1.png"));
+	m_gameData->imgField2 = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + std::string("/field2.png"));
+	m_gameData->imgBorder1 = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + std::string("/border1.png"));
+	m_gameData->imgBorder2 = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + std::string("/border2.png"));
+	m_gameData->imgPlayerBorder = m_gameData->front->loadImage(m_baseAssetDir + "Data/border.png");
+	m_gameData->imgSpice = m_gameData->front->loadImage(m_baseAssetDir + "Data/spice.png");
+
+	// Other
+	m_gameData->imgScore = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + std::string("/score.png"));
+	m_gameData->imgAllClear = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + std::string("/allclear.png"));
+	m_gameData->imgLose = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + std::string("/lose.png"));
+	m_gameData->imgWin = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + std::string("/win.png"));
+	m_gameData->imgFeverGauge = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + std::string("/fgauge.png"));
+	m_gameData->imgSeconds = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + std::string("/fcounter.png"));
+	m_gameData->imgCharHolder = m_gameData->front->loadImage(m_baseAssetDir + "Data/CharSelect/charHolder.png");
+	m_gameData->imgNameHolder = m_gameData->front->loadImage(m_baseAssetDir + "Data/CharSelect/nameHolder.png");
+	m_gameData->imgBlack = m_gameData->front->loadImage(m_baseAssetDir + "Data/CharSelect/black.png");
+	m_gameData->imgDropSet = m_gameData->front->loadImage(m_baseAssetDir + "Data/CharSelect/dropset.png");
+	m_gameData->imgChain = m_gameData->front->loadImage(m_baseAssetDir + std::string("User/Backgrounds/") + m_gameData->gUserSettings.backgroundDirPath + std::string("/chain.png"));
+	m_gameData->imgCheckMark = m_gameData->front->loadImage(m_baseAssetDir + "Data/checkmark.png");
+	m_gameData->imgPlayerCharSelect = m_gameData->front->loadImage(m_baseAssetDir + "Data/CharSelect/charSelect.png");
+
+	for (int i = 0; i < kNumCharacters; ++i) {
+		m_gameData->imgCharField[i] = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserCharacter + m_game->m_settings->characterSetup[static_cast<PuyoCharacter>(i)] + "/field.png");
+		m_gameData->imgCharSelect[i] = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserCharacter + m_game->m_settings->characterSetup[static_cast<PuyoCharacter>(i)] + "/select.png");
+		m_gameData->imgCharName[i] = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserCharacter + m_game->m_settings->characterSetup[static_cast<PuyoCharacter>(i)] + "/name.png");
+		m_gameData->imgSelect[i] = m_gameData->front->loadImage(m_baseAssetDir + kFolderUserCharacter + m_game->m_settings->characterSetup[static_cast<PuyoCharacter>(i)] + "/select.png");
+	}
+
+	m_gameData->imgPlayerNumber = m_gameData->front->loadImage(m_baseAssetDir + "Data/CharSelect/playernumber.png");
+
+}
+
+void GameRenderer::loadAudio() const
+{
+	Sounds& snd = m_gameData->snd;
+	setBuffer(snd.chain[0], (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/chain1.ogg"))));
+	setBuffer(snd.chain[1], (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/chain2.ogg"))));
+	setBuffer(snd.chain[2], (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/chain3.ogg"))));
+	setBuffer(snd.chain[3], (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/chain4.ogg"))));
+	setBuffer(snd.chain[4], (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/chain5.ogg"))));
+	setBuffer(snd.chain[5], (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/chain6.ogg"))));
+	setBuffer(snd.chain[6], (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/chain7.ogg"))));
+	setBuffer(snd.allClearDrop, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/allclear.ogg"))));
+	setBuffer(snd.drop, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/drop.ogg"))));
+	setBuffer(snd.fever, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/fever.ogg"))));
+	setBuffer(snd.feverLight, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/feverlight.ogg"))));
+	setBuffer(snd.feverTimeCount, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/fevertimecount.ogg"))));
+	setBuffer(snd.feverTimeEnd, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/fevertimeend.ogg"))));
+	setBuffer(snd.go, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/go.ogg"))));
+	setBuffer(snd.heavy, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/heavy.ogg"))));
+	setBuffer(snd.hit, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/hit.ogg"))));
+	setBuffer(snd.lose, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/lose.ogg"))));
+	setBuffer(snd.move, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/move.ogg"))));
+	setBuffer(snd.nuisanceHitL, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/nuisance_hitL.ogg"))));
+	setBuffer(snd.nuisanceHitM, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/nuisance_hitM.ogg"))));
+	setBuffer(snd.nuisanceHitS, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/nuisance_hitS.ogg"))));
+	setBuffer(snd.nuisanceL, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/nuisanceL.ogg"))));
+	setBuffer(snd.nuisanceS, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/nuisanceS.ogg"))));
+	setBuffer(snd.ready, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/ready.ogg"))));
+	setBuffer(snd.rotate, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/rotate.ogg"))));
+	setBuffer(snd.win, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/win.ogg"))));
+	setBuffer(snd.decide, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/decide.ogg"))));
+	setBuffer(snd.cancel, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/cancel.ogg"))));
+	setBuffer(snd.cursor, (m_gameData->front->loadSound(kFolderUserSounds + m_gameData->gUserSettings.sfxDirPath + std::string("/cursor.ogg"))));
+
+}
+
 } // ppvs

--- a/Puyolib/GameRenderer.cpp
+++ b/Puyolib/GameRenderer.cpp
@@ -16,6 +16,8 @@ GameRenderer::~GameRenderer()
 	delete m_statusFont;
 	delete m_gameData->front;
 	delete m_gameData;
+	delete m_mainMenu;
+	delete m_charSelectMenu;
 }
 
 void GameRenderer::initRenderer(Frontend* f)
@@ -73,9 +75,7 @@ void GameRenderer::initRenderer(Frontend* f)
 	m_backgroundAnimation.init(m_gameData, PosVectorFloat(320, 240), 1, m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + "/Animation/", "animation.xml", 30 * 60);
 	m_backgroundAnimation.prepareAnimation("background");
 
-	m_charSelectMenu = new CharacterSelect(m_game);
-	m_charSelectMenu->prepare();
-	m_mainMenu = new Menu(m_game);
+
 
 	m_timerSprite[0].setImage(m_gameData->imgPlayerNumber);
 	m_timerSprite[1].setImage(m_gameData->imgPlayerNumber);
@@ -86,6 +86,12 @@ void GameRenderer::initRenderer(Frontend* f)
 	m_timerSprite[0].setPosition(640 - 24, 32);
 	m_timerSprite[1].setPosition(640 - 24 - 24, 32);
 
+}
+void GameRenderer::initMenus()
+{
+	m_charSelectMenu = new CharacterSelect(m_game);
+	m_charSelectMenu->prepare();
+	m_mainMenu = new Menu(m_game);
 }
 
 void GameRenderer::setStatusText(const char* utf8)

--- a/Puyolib/GameRenderer.cpp
+++ b/Puyolib/GameRenderer.cpp
@@ -1,0 +1,8 @@
+//
+// Created by krab on 24.6.23.
+//
+
+#include "GameRenderer.h"
+
+namespace ppvs {
+} // ppvs

--- a/Puyolib/GameRenderer.cpp
+++ b/Puyolib/GameRenderer.cpp
@@ -63,6 +63,29 @@ void GameRenderer::initRenderer(Frontend* f)
 
 	m_statusFont = m_gameData->front->loadFont("Arial", 14);
 	setStatusText("");
+
+	// Game::initGame
+
+	m_backgroundSprite.setImage(m_gameData->imgBackground);
+	m_backgroundSprite.setPosition(0.f,0.f);
+
+	m_readyGoObj.init(m_gameData, PosVectorFloat(320, 240), 1, m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + "/Animation/", "ready.xml", 3 * 60);
+	m_backgroundAnimation.init(m_gameData, PosVectorFloat(320, 240), 1, m_baseAssetDir + kFolderUserBackgrounds + m_gameData->gUserSettings.backgroundDirPath + "/Animation/", "animation.xml", 30 * 60);
+	m_backgroundAnimation.prepareAnimation("background");
+
+	m_charSelectMenu = new CharacterSelect(m_game);
+	m_charSelectMenu->prepare();
+	m_mainMenu = new Menu(m_game);
+
+	m_timerSprite[0].setImage(m_gameData->imgPlayerNumber);
+	m_timerSprite[1].setImage(m_gameData->imgPlayerNumber);
+	m_timerSprite[0].setSubRect(0 / 10 * 24, 0, 0, 32);
+	m_timerSprite[1].setSubRect(0 / 10 * 24, 0, 0, 32);
+	m_timerSprite[0].setCenterBottom();
+	m_timerSprite[1].setCenterBottom();
+	m_timerSprite[0].setPosition(640 - 24, 32);
+	m_timerSprite[1].setPosition(640 - 24 - 24, 32);
+
 }
 
 void GameRenderer::setStatusText(const char* utf8)

--- a/Puyolib/GameRenderer.cpp
+++ b/Puyolib/GameRenderer.cpp
@@ -8,6 +8,13 @@ namespace ppvs {
 GameRenderer::GameRenderer(ppvs::Game* game)
 	: m_game(game)
 {
+	// Blanking cloak sprite
+	m_black.setImage(nullptr);
+	m_black.setScale(640 * 2, 480);
+	m_black.setColor(0, 0, 0);
+	m_black.setTransparency(0.5f);
+	m_black.setPosition(-640.f / 2.f, -480.f / 4.f);
+
 }
 
 GameRenderer::~GameRenderer()

--- a/Puyolib/GameRenderer.h
+++ b/Puyolib/GameRenderer.h
@@ -45,6 +45,8 @@ public:
 	CharacterSelect* m_charSelectMenu = nullptr;
 	Menu* m_mainMenu = nullptr;
 
+	Sprite m_backgroundSprite {};
+	Sprite m_black {};
 
 private:
 	int m_targetVolumeNormal = 100;
@@ -58,11 +60,12 @@ private:
 	FeText* m_statusText = nullptr;
 	std::string m_lastText;
 	void setStatusText(const char* utf8);
-	Sprite m_backgroundSprite {};
 
 	// Timers
 	int m_timerEndMatch = 0;
 	Sprite m_timerSprite[2] {};
+
+
 
 };
 

--- a/Puyolib/GameRenderer.h
+++ b/Puyolib/GameRenderer.h
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPLv3
 
 #pragma once
-#include "global.h"
 #include "Game.h"
+
 namespace ppvs {
 
 class GameRenderer {
@@ -26,7 +26,11 @@ public:
 	void changeMusicVolume(int state);
 	void continueMusic();
 
+	// Parent objects
+	Game* m_game = nullptr;
+
 	// Public variables
+	GameData* m_gameData = nullptr;
 	Animation m_readyGoObj {};
 	Animation m_backgroundAnimation {};
 	GameData* m_imageData = nullptr;
@@ -41,6 +45,15 @@ private:
 	int m_targetVolumeFever = 100;
 	int m_currentVolumeFever = 100;
 	float m_globalVolume = 1.f;
+
+	// Status text
+	FeFont* m_statusFont = nullptr;
+	FeText* m_statusText = nullptr;
+	std::string m_lastText;
+	void setStatusText(const char* utf8);
+
+
+
 
 };
 

--- a/Puyolib/GameRenderer.h
+++ b/Puyolib/GameRenderer.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2023, LossRain
+// SPDX-License-Identifier: GPLv3
+
+#pragma once
+#include "global.h"
+#include "Game.h"
+namespace ppvs {
+
+class GameRenderer {
+public:
+	explicit GameRenderer(Game* game);
+	~GameRenderer();
+
+	void close();
+
+	// Init functions
+	void initRenderer(Frontend* f);
+	void loadImages() const;
+	void loadAudio() const;
+
+	// Video related
+	void renderGame();
+	void setWindowFocus(bool focus) const;
+
+	// Audio related
+	void changeMusicVolume(int state);
+	void continueMusic();
+
+	// Public variables
+	Animation m_readyGoObj {};
+	Animation m_backgroundAnimation {};
+	GameData* m_imageData = nullptr;
+	TranslatableStrings m_translatableStrings {};
+	std::string m_baseAssetDir;
+	std::string m_winsString;
+
+
+private:
+	int m_targetVolumeNormal = 100;
+	int m_currentVolumeNormal = 0;
+	int m_targetVolumeFever = 100;
+	int m_currentVolumeFever = 100;
+	float m_globalVolume = 1.f;
+
+};
+
+} // ppvs
+

--- a/Puyolib/GameRenderer.h
+++ b/Puyolib/GameRenderer.h
@@ -18,6 +18,7 @@ public:
 	void initRenderer(Frontend* f);
 	void loadImages() const;
 	void loadAudio() const;
+	void initMenus();
 
 	// Video related
 	void renderGame();

--- a/Puyolib/GameRenderer.h
+++ b/Puyolib/GameRenderer.h
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPLv3
 
 #pragma once
-#include "Game.h"
 #include "CharacterSelect.h"
+#include "Game.h"
 
 namespace ppvs {
 
@@ -32,6 +32,8 @@ public:
 	Game* m_game = nullptr;
 
 	// Public variables
+	Frontend* frontend = nullptr;
+
 	GameData* m_gameData = nullptr;
 	Animation m_readyGoObj {};
 	Animation m_backgroundAnimation {};
@@ -40,10 +42,11 @@ public:
 	std::string m_baseAssetDir;
 	std::string m_winsString;
 
-
 	// Menus
 	CharacterSelect* m_charSelectMenu = nullptr;
 	Menu* m_mainMenu = nullptr;
+
+	void setStatusText(const char* utf8);
 
 	Sprite m_backgroundSprite {};
 	Sprite m_black {};
@@ -59,15 +62,14 @@ private:
 	FeFont* m_statusFont = nullptr;
 	FeText* m_statusText = nullptr;
 	std::string m_lastText;
-	void setStatusText(const char* utf8);
+
 
 	// Timers
 	int m_timerEndMatch = 0;
 	Sprite m_timerSprite[2] {};
 
-
-
+	// Helper functions
+	bool shouldDrawTimer();
 };
 
 } // ppvs
-

--- a/Puyolib/GameRenderer.h
+++ b/Puyolib/GameRenderer.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include "Game.h"
+#include "CharacterSelect.h"
 
 namespace ppvs {
 
@@ -39,6 +40,11 @@ public:
 	std::string m_winsString;
 
 
+	// Menus
+	CharacterSelect* m_charSelectMenu = nullptr;
+	Menu* m_mainMenu = nullptr;
+
+
 private:
 	int m_targetVolumeNormal = 100;
 	int m_currentVolumeNormal = 0;
@@ -51,9 +57,11 @@ private:
 	FeText* m_statusText = nullptr;
 	std::string m_lastText;
 	void setStatusText(const char* utf8);
+	Sprite m_backgroundSprite {};
 
-
-
+	// Timers
+	int m_timerEndMatch = 0;
+	Sprite m_timerSprite[2] {};
 
 };
 

--- a/Puyolib/Menu.cpp
+++ b/Puyolib/Menu.cpp
@@ -12,6 +12,7 @@ Menu::Menu(Game* g)
 	m_background.setScale(2 * 192, 336);
 	m_background.setColor(0, 0, 0);
 	m_background.setTransparency(0.5f);
+	assert(m_currentGame->m_players!=nullptr);
 	const FieldProp p = m_currentGame->m_players[0]->m_activeField->getProperties();
 	m_background.setPosition(p.offsetX - 192.f / 2.f, p.offsetY - 336.f / 4.f);
 	m_select = 0;

--- a/Puyolib/Menu.cpp
+++ b/Puyolib/Menu.cpp
@@ -7,7 +7,7 @@ namespace ppvs {
 Menu::Menu(Game* g)
 {
 	m_currentGame = g;
-	m_data = g->m_data;
+	m_data = g->m_gameRenderer->m_gameData;
 	m_background.setImage(nullptr);
 	m_background.setScale(2 * 192, 336);
 	m_background.setColor(0, 0, 0);

--- a/Puyolib/Player.cpp
+++ b/Puyolib/Player.cpp
@@ -10,11 +10,11 @@ using namespace std;
 namespace ppvs {
 
 Player::Player(const PlayerType type, const int playerNum, const int totalPlayers, Game* g)
-	: m_feverGauge(g->m_data)
-	, m_feverLight(g->m_data)
+	: m_feverGauge(g->m_gameRenderer->m_gameData)
+	, m_feverLight(g->m_gameRenderer->m_gameData)
 {
 	m_currentGame = g;
-	m_data = m_currentGame->m_data;
+	m_data = m_currentGame->m_gameRenderer->m_gameData;
 	m_debug = 0;
 	m_debugCounter = 0;
 

--- a/Puyolib/RuleSet/RuleSet.cpp
+++ b/Puyolib/RuleSet/RuleSet.cpp
@@ -123,7 +123,7 @@ void RuleSet::setRules(const Rules ruleString)
 void RuleSet::setGame(Game* g)
 {
 	m_currentGame = g;
-	m_data = g->m_data;
+	m_data = g->m_gameRenderer->m_gameData;
 	this->onSetGame();
 }
 

--- a/Puyolib/global.h
+++ b/Puyolib/global.h
@@ -74,6 +74,20 @@ enum class RecordState : int {
 	REPLAYING,
 };
 
+enum MenuState : int {
+	NO_MENU = 0,
+	CHAR_SELECT_MENU,
+	MAIN_MENU,
+	INVALID = -1
+};
+
+enum RankedMatchState: int {
+ 	RANKED_WAITING_FOR_MATCH = 0,
+ 	RANKED_UNNATURAL_DISCONNECT,
+ 	RANKED_END_OF_MATCH,
+	RANKED_DESTROYED_MATCH
+};
+
 // Global sounds struct
 struct Sounds {
 	Sound allClearDrop, drop, feverLight, fever, feverTimeCount, feverTimeEnd, go, heavy, hit, lose, move,

--- a/Puyolib/glowShader.vs
+++ b/Puyolib/glowShader.vs
@@ -1,0 +1,8 @@
+R"(
+uniform sampler2D tex;
+uniform float color;
+void main()
+{
+   gl_FragColor=texture2D(tex,gl_TexCoord[0].xy)+vec4(color,color,color,0);
+}
+    )"

--- a/Puyolib/tunnelShader.vs
+++ b/Puyolib/tunnelShader.vs
@@ -1,0 +1,19 @@
+R"(
+uniform vec4 cl;
+uniform float time;
+uniform sampler2D tex;
+void main(void) {
+    vec2 ccord = gl_TexCoord[0].xy;
+    vec2 pcord;
+    vec2 final;
+    float zoomspeed=0.5;
+    float rotatespeed=0.25;
+    ccord.x = step(0.5,ccord.y)*(-1.0+ 2.0*ccord.x)-(1.0-step(0.5,ccord.y))*(-1.0+ 2.0*ccord.x);
+    ccord.y = step(0.5,ccord.y)*(-1.0+ 2.0*ccord.y)-(1.0-step(0.5,ccord.y))*(-1.0+ 2.0*ccord.y);
+    pcord.x = 0.1/sqrt(ccord.x*ccord.x+ccord.y*ccord.y);pcord.y = atan(ccord.y,ccord.x)/3.141592;
+    final.x = step(0.25,pcord.x)*mod(pcord.x+zoomspeed*time,0.5)+(1.0-step(0.25,pcord.x))*mod(pcord.x+zoomspeed*time,0.5);
+    final.y = step(0.25,pcord.y)*mod(pcord.y+rotatespeed*time,0.5)+(1.0-step(0.25,pcord.y))*mod(pcord.y+rotatespeed*time,0.5);
+    vec3 col = texture2D(tex,final).xyz;
+    gl_FragColor = vec4(max(col/((pcord/0.1).x),0.1), 1.0) * cl;
+};
+)"

--- a/Puyolib/tunnelShader.vs
+++ b/Puyolib/tunnelShader.vs
@@ -10,7 +10,8 @@ void main(void) {
     float rotatespeed=0.25;
     ccord.x = step(0.5,ccord.y)*(-1.0+ 2.0*ccord.x)-(1.0-step(0.5,ccord.y))*(-1.0+ 2.0*ccord.x);
     ccord.y = step(0.5,ccord.y)*(-1.0+ 2.0*ccord.y)-(1.0-step(0.5,ccord.y))*(-1.0+ 2.0*ccord.y);
-    pcord.x = 0.1/sqrt(ccord.x*ccord.x+ccord.y*ccord.y);pcord.y = atan(ccord.y,ccord.x)/3.141592;
+    pcord.x = 0.1/sqrt(ccord.x*ccord.x+ccord.y*ccord.y);
+    pcord.y = atan(ccord.y,ccord.x)/3.141592;
     final.x = step(0.25,pcord.x)*mod(pcord.x+zoomspeed*time,0.5)+(1.0-step(0.25,pcord.x))*mod(pcord.x+zoomspeed*time,0.5);
     final.y = step(0.25,pcord.y)*mod(pcord.y+rotatespeed*time,0.5)+(1.0-step(0.25,pcord.y))*mod(pcord.y+rotatespeed*time,0.5);
     vec3 col = texture2D(tex,final).xyz;


### PR DESCRIPTION
This PR is a roadmap for the overhaul of **Puyolib**, the internal game-handling library. In the finale it will be a complete library for game-related problems that relies as little as possible on our configuration (such as network protocol or game client) with possible exceptions. This is an alive post. 

# The plan

- [ ] Extract all non-core code (notably all rendering and network logic) in Puyolib into separate classes to make the codebase readable and hopefully modular
  - [X] Game
  - [ ] Player
  - [ ] ...
- [ ] Review the code and eliminate all redundant, ugly, slow and unsafe operations
  - [ ] Splice up the GameData object
  - [ ] Move all data (de)serialization outside to an intermediate interface
  - [ ] Remove hard-coded filenames in favor of enumerators and similar 
  - [ ] Remove our dependency on hard-coded and potentially problematic constants (such as character names, their total count, etc.)
  - [ ] ...
- [ ]  Create reasonable interfaces for managing internal parameters ( no more haphazardly changing values in seemingly random parts of objects)

Small additions, fixes and changes shall be included without further comment. 

PS: I understand that making such bold plans without much code to back it up is foolish and that my approach will lead me to refactor the same code several times but yet I believe it will force me to be accountable to myself and will not overwhelm me as much.
