### PR TITLE
Puyolib: Basic console debug

### DIFF
--- a/Client/gamemanager.cpp
+++ b/Client/gamemanager.cpp
@@ -65,7 +65,7 @@ GameManager::~GameManager()
 {
 	delete audio;
 	loopEnabled = false;
-	delete dbg;
+	
 	emit exiting();
 }
 

--- a/Client/gamemanager.cpp
+++ b/Client/gamemanager.cpp
@@ -15,10 +15,25 @@
 
 volatile bool loopEnabled;
 
-void GameManager::handleDebugLog(std::basic_string<char> text, ppvs::DebugMessageType severity)
+/* Handles the Puyolib debug information transfer. See Puyolib/DebugLog.h for more info. */
+void GameManager::handleDebugLog(const std::basic_string<char>& text, ppvs::DebugMessageType severity)
 {
-	if (severity != ppvs::DebugMessageType::NONE) {
+	switch (severity) {
+	case ppvs::DebugMessageType::DEBUG:
 		qDebug().noquote() << "Puyolib:" << QString(text.c_str()) << '\n';
+		return;
+	case ppvs::DebugMessageType::INFO:
+		qInfo().noquote() << "Puyolib:" << QString(text.c_str()) << '\n';
+		return;
+	case ppvs::DebugMessageType::WARNING:
+		qWarning().noquote() << "Puyolib:" << QString(text.c_str()) << '\n';
+		return;
+	case ppvs::DebugMessageType::ERROR:
+		qCritical().noquote() << "Puyolib:" << QString(text.c_str()) << '\n';
+		return;
+	case ppvs::DebugMessageType::NONE:
+	default:
+		return;
 	}
 }
 
@@ -119,7 +134,7 @@ ppvs::RuleSetInfo GameManager::createRules()
 
 	return rs;
 }
-
+/* Creates a new instance of DebugLog */
 ppvs::DebugLog* GameManager::createDebug()
 {
 	dbg = new ppvs::DebugLog;
@@ -175,7 +190,6 @@ GameWidget* GameManager::createGame(ppvs::GameSettings* gs, const QString& roomN
 
 	gs->playMusic = settings.boolean("launcher", "enablemusic", true);
 	gs->playSound = settings.boolean("launcher", "enablesound", true);
-
 
 	ppvs::Game* game = new ppvs::Game(gs, createDebug());
 

--- a/Client/gamemanager.cpp
+++ b/Client/gamemanager.cpp
@@ -22,7 +22,9 @@ void GameManager::handleDebugLog(std::string text, ppvs::DebugMessageType severi
 {
 	switch (severity) {
 	case ppvs::DebugMessageType::DEBUG:
-		qDebug("Puyolib: %s\n",text.c_str());
+		// Do not display debug info if we aren't in Puyolib debug mode
+		if (ppvs::debugMode)
+			qDebug("Puyolib: %s\n",text.c_str());
 		return;
 	case ppvs::DebugMessageType::INFO:
 		qInfo("Puyolib: %s\n",text.c_str());

--- a/Client/gamemanager.cpp
+++ b/Client/gamemanager.cpp
@@ -21,21 +21,21 @@ volatile bool loopEnabled;
 void GameManager::handleDebugLog(std::string text, ppvs::DebugMessageType severity)
 {
 	switch (severity) {
-	case ppvs::DebugMessageType::DEBUG:
+	case ppvs::DebugMessageType::Debug:
 		// Do not display debug info if we aren't in Puyolib debug mode
 		if (ppvs::debugMode)
 			qDebug("Puyolib: %s\n",text.c_str());
 		return;
-	case ppvs::DebugMessageType::INFO:
+	case ppvs::DebugMessageType::Info:
 		qInfo("Puyolib: %s\n",text.c_str());
 		return;
-	case ppvs::DebugMessageType::WARNING:
+	case ppvs::DebugMessageType::Warning:
 		qWarning("Puyolib WARNING: %s\n",text.c_str());
 		return;
-	case ppvs::DebugMessageType::ERROR:
+	case ppvs::DebugMessageType::Error:
 		qCritical("Puyolib ERROR: %s\n",text.c_str());
 		return;
-	case ppvs::DebugMessageType::NONE:
+	case ppvs::DebugMessageType::None:
 	default:
 		return;
 	}

--- a/Client/gamemanager.cpp
+++ b/Client/gamemanager.cpp
@@ -15,21 +15,23 @@
 
 volatile bool loopEnabled;
 
+
+// TODO: Add support to std::format when we switch to C++20
 /* Handles the Puyolib debug information transfer. See Puyolib/DebugLog.h for more info. */
-void GameManager::handleDebugLog(const std::basic_string<char>& text, ppvs::DebugMessageType severity)
+void GameManager::handleDebugLog(std::string text, ppvs::DebugMessageType severity)
 {
 	switch (severity) {
 	case ppvs::DebugMessageType::DEBUG:
-		qDebug().noquote() << "Puyolib:" << QString(text.c_str()) << '\n';
+		qDebug("Puyolib: %s\n",text.c_str());
 		return;
 	case ppvs::DebugMessageType::INFO:
-		qInfo().noquote() << "Puyolib:" << QString(text.c_str()) << '\n';
+		qInfo("Puyolib: %s\n",text.c_str());
 		return;
 	case ppvs::DebugMessageType::WARNING:
-		qWarning().noquote() << "Puyolib:" << QString(text.c_str()) << '\n';
+		qWarning("Puyolib WARNING: %s\n",text.c_str());
 		return;
 	case ppvs::DebugMessageType::ERROR:
-		qCritical().noquote() << "Puyolib:" << QString(text.c_str()) << '\n';
+		qCritical("Puyolib ERROR: %s\n",text.c_str());
 		return;
 	case ppvs::DebugMessageType::NONE:
 	default:
@@ -65,7 +67,7 @@ GameManager::~GameManager()
 {
 	delete audio;
 	loopEnabled = false;
-	
+
 	emit exiting();
 }
 
@@ -138,7 +140,7 @@ ppvs::RuleSetInfo GameManager::createRules()
 ppvs::DebugLog* GameManager::createDebug()
 {
 	dbg = new ppvs::DebugLog;
-	dbg->setLogHandler([this](std::basic_string<char> text, ppvs::DebugMessageType sev) { this->handleDebugLog(text, sev); });
+	dbg->setLogHandler([this](std::string text, ppvs::DebugMessageType sev) { this->handleDebugLog(text, sev); });
 	return dbg;
 }
 

--- a/Client/gamemanager.h
+++ b/Client/gamemanager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../Puyolib/GameSettings.h" // ppvs::RuleSetInfo
+#include "../Puyolib/DebugLog.h" // ppvs::DebugLog
 #include "netclient.h"
 #include <QBasicTimer>
 #include <QList>
@@ -22,9 +23,13 @@ public:
 	bool closeAll();
 	void exec();
 
+
+
 public slots:
 	void addGame(GameWidget* game);
 	ppvs::RuleSetInfo createRules();
+
+	ppvs::DebugLog* createDebug();
 	GameWidget* createGame(const QString& rules, const QString& roomName, bool spectating = false);
 	GameWidget* createGame(ppvs::GameSettings* gamesettings, const QString& roomName, bool spectating = false, bool replay = false);
 	GameWidget* findGame(const QString& roomName) const;
@@ -45,10 +50,14 @@ signals:
 	void exiting();
 
 protected:
+	void handleDebugLog(std::string text, ppvs::DebugMessageType);
+
 	void process() const;
 	bool getGame(const QString& channel, ppvs::Game*& game, GameWidget*& widget) const;
 
 	QList<GameWidget*> games;
 	NetClient* network;
 	GameAudio* audio;
+
+	ppvs::DebugLog* dbg;
 };

--- a/Client/gamemanager.h
+++ b/Client/gamemanager.h
@@ -6,6 +6,7 @@
 #include <QBasicTimer>
 #include <QList>
 #include <QObject>
+#include <string>
 
 class GameAudio;
 class GameWidget;
@@ -50,7 +51,7 @@ signals:
 	void exiting();
 
 protected:
-	static void handleDebugLog(const std::string& text, ppvs::DebugMessageType severity);
+	static void handleDebugLog(std::string text, ppvs::DebugMessageType severity);
 
 	void process() const;
 	bool getGame(const QString& channel, ppvs::Game*& game, GameWidget*& widget) const;

--- a/Client/gamemanager.h
+++ b/Client/gamemanager.h
@@ -50,7 +50,7 @@ signals:
 	void exiting();
 
 protected:
-	void handleDebugLog(std::string text, ppvs::DebugMessageType);
+	static void handleDebugLog(const std::string& text, ppvs::DebugMessageType severity);
 
 	void process() const;
 	bool getGame(const QString& channel, ppvs::Game*& game, GameWidget*& widget) const;

--- a/ClientNG/Scenes/Game/InGame.cpp
+++ b/ClientNG/Scenes/Game/InGame.cpp
@@ -4,7 +4,37 @@
 #include "../../Game.h"
 #include "Frontend.h"
 
+namespace PuyoVS::ClientNG {
+
+using ppvs::DebugMessageType;
+
+// TODO: Move to the right place. Maybe our current handler is too smart but some current clients are just too dumb.
+/* Handles printing debug information to the terminal */
+void handlePuyolibDebugLog(std::string text, DebugMessageType sev)
+{
+	switch (sev) {
+	case DebugMessageType::DEBUG:
+		SDL_LogDebug(0, "Puyolib: %s", text.c_str());
+		return;
+	case DebugMessageType::INFO:
+		SDL_LogInfo(0, "Puyolib: %s", text.c_str());
+		return;
+	case DebugMessageType::WARNING:
+		SDL_LogWarn(0, "Puyolib: %s", text.c_str());
+		return;
+	case DebugMessageType::ERROR:
+		SDL_LogError(0, "Puyolib: %s", text.c_str());
+		return;
+	case DebugMessageType::NONE:
+	default:
+		return;
+	}
+}
+
+}
+
 namespace PuyoVS::ClientNG::Scenes::Game {
+
 
 InGame::InGame(GameWindow& w, std::unique_ptr<ppvs::Game> game)
 	: Scene(w.renderTarget())
@@ -51,5 +81,6 @@ void InGame::draw()
 	}
 	m_target->present();
 }
+
 
 }

--- a/ClientNG/Scenes/Game/InGame.cpp
+++ b/ClientNG/Scenes/Game/InGame.cpp
@@ -13,19 +13,19 @@ using ppvs::DebugMessageType;
 void handlePuyolibDebugLog(std::string text, DebugMessageType sev)
 {
 	switch (sev) {
-	case DebugMessageType::DEBUG:
+	case DebugMessageType::Debug:
 		SDL_LogDebug(0, "Puyolib: %s", text.c_str());
 		return;
-	case DebugMessageType::INFO:
+	case DebugMessageType::Info:
 		SDL_LogInfo(0, "Puyolib: %s", text.c_str());
 		return;
-	case DebugMessageType::WARNING:
+	case DebugMessageType::Warning:
 		SDL_LogWarn(0, "Puyolib: %s", text.c_str());
 		return;
-	case DebugMessageType::ERROR:
+	case DebugMessageType::Error:
 		SDL_LogError(0, "Puyolib: %s", text.c_str());
 		return;
-	case DebugMessageType::NONE:
+	case DebugMessageType::None:
 	default:
 		return;
 	}

--- a/ClientNG/Scenes/Game/InGame.h
+++ b/ClientNG/Scenes/Game/InGame.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "../Scene.h"
+#include "../../../Puyolib/Game.h"
 #include <memory>
 
 namespace ppvs {
@@ -8,6 +9,9 @@ class Game;
 }
 
 namespace PuyoVS::ClientNG {
+
+void handlePuyolibDebugLog(std::string text, ppvs::DebugMessageType sev);
+
 class GameWindow;
 }
 
@@ -24,8 +28,11 @@ public:
 	void update(double t) override;
 	void draw() override;
 
+
+
 private:
 	GameWindow& m_window;
+	std::unique_ptr<ppvs::DebugLog> m_debug;
 	std::unique_ptr<ppvs::Game> m_game;
 	GameFrontend* m_frontend;
 	double m_fadeVal = 1.0;

--- a/ClientNG/Scenes/Intro/IntroNotes.cpp
+++ b/ClientNG/Scenes/Intro/IntroNotes.cpp
@@ -90,7 +90,9 @@ void IntroNotes::finish()
 	auto gs = new ppvs::GameSettings();
 	gs->useCpuPlayers = true;
 	gs->baseAssetDir = std::string(defaultAssetPath) + "/";
-	m_window.setScene(std::make_unique<Game::InGame>(m_window, std::make_unique<ppvs::Game>(gs)));
+	auto dbg = new ppvs::DebugLog();
+	dbg->setLogHandler([this](std::string text, ppvs::DebugMessageType sev) { PuyoVS::ClientNG::handlePuyolibDebugLog(text, sev); });
+	m_window.setScene(std::make_unique<Game::InGame>(m_window, std::make_unique<ppvs::Game>(gs,dbg)));
 }
 
 }

--- a/Puyolib/CMakeLists.txt
+++ b/Puyolib/CMakeLists.txt
@@ -30,7 +30,8 @@ add_library(Puyolib
     RNG/LegacyPuyoRng.cpp
     RNG/MersenneTwister.cpp
     RNG/PuyoRng.cpp
-        DebugLog.cpp DebugLog.h)
+    DebugLog.cpp
+    DebugLog.h)
 
 target_compile_features(Puyolib PUBLIC cxx_std_17)
 

--- a/Puyolib/CMakeLists.txt
+++ b/Puyolib/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(Puyolib
     RNG/LegacyPuyoRng.cpp
     RNG/MersenneTwister.cpp
     RNG/PuyoRng.cpp
-)
+        DebugLog.cpp DebugLog.h)
 
 target_compile_features(Puyolib PUBLIC cxx_std_17)
 

--- a/Puyolib/DebugLog.cpp
+++ b/Puyolib/DebugLog.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2023, LossRain
+// SPDX-License-Identifier: GPLv3
+
+#include "DebugLog.h"
+
+namespace ppvs {
+
+DebugLog::~DebugLog() {
+	m_log_handler = NULL;
+}
+
+void DebugLog::setLogHandler(std::function<void(std::basic_string<char>, DebugMessageType)> func)
+{
+	m_log_handler = func;
+	log("Debug Log was successfully linked", DebugMessageType::DEBUG);
+}
+
+void DebugLog::log(ppvs::DebugMessage* msg)
+{
+	if (m_log_handler != NULL) {
+		m_log_handler(msg->m_text, msg->m_severity);
+	}
+	delete msg;
+}
+
+void DebugLog::log(std::string text, DebugMessageType severity)
+{
+	if (m_log_handler != NULL) {
+		m_log_handler(text, severity);
+	}
+}
+
+} // ppvs

--- a/Puyolib/DebugLog.cpp
+++ b/Puyolib/DebugLog.cpp
@@ -6,15 +6,20 @@
 namespace ppvs {
 
 DebugLog::~DebugLog() {
+	// Assumes that log handler isn't dead yet
+	log("Debug Log was successfully destroyed", DebugMessageType::INFO);
 	m_log_handler = NULL;
 }
 
 void DebugLog::setLogHandler(std::function<void(std::basic_string<char>, DebugMessageType)> func)
 {
 	m_log_handler = func;
-	log("Debug Log was successfully linked", DebugMessageType::DEBUG);
+	log("Debug Log was successfully created", DebugMessageType::INFO);
 }
 
+/* Sends the Debug message to the client.
+ * Before calling: make sure that the logging handler is deployed and bound.
+ * */
 void DebugLog::log(ppvs::DebugMessage* msg)
 {
 	if (m_log_handler != NULL) {
@@ -23,7 +28,10 @@ void DebugLog::log(ppvs::DebugMessage* msg)
 	delete msg;
 }
 
-void DebugLog::log(std::string text, DebugMessageType severity)
+/* Sends the text to the client to display as debug output. The text should be a std::string object.
+ * Before calling: make sure that the logging handler is deployed and bound.
+ * */
+void DebugLog::log(std::string text, DebugMessageType severity = DebugMessageType::DEBUG)
 {
 	if (m_log_handler != NULL) {
 		m_log_handler(text, severity);

--- a/Puyolib/DebugLog.cpp
+++ b/Puyolib/DebugLog.cpp
@@ -11,7 +11,7 @@ DebugLog::~DebugLog() {
 	m_log_handler = nullptr;
 }
 
-void DebugLog::setLogHandler(std::function<void(std::string, DebugMessageType)> func)
+void DebugLog::setLogHandler(function<void(std::string, DebugMessageType)> func)
 {
 	m_log_handler = func;
 	log("Debug Log was successfully created", DebugMessageType::INFO);

--- a/Puyolib/DebugLog.cpp
+++ b/Puyolib/DebugLog.cpp
@@ -8,10 +8,10 @@ namespace ppvs {
 DebugLog::~DebugLog() {
 	// Assumes that log handler isn't dead yet
 	log("Debug Log was successfully destroyed", DebugMessageType::INFO);
-	m_log_handler = NULL;
+	m_log_handler = nullptr;
 }
 
-void DebugLog::setLogHandler(std::function<void(std::basic_string<char>, DebugMessageType)> func)
+void DebugLog::setLogHandler(std::function<void(std::string, DebugMessageType)> func)
 {
 	m_log_handler = func;
 	log("Debug Log was successfully created", DebugMessageType::INFO);

--- a/Puyolib/DebugLog.cpp
+++ b/Puyolib/DebugLog.cpp
@@ -7,14 +7,14 @@ namespace ppvs {
 
 DebugLog::~DebugLog() {
 	// Assumes that log handler isn't dead yet
-	log("Debug Log was successfully destroyed", DebugMessageType::INFO);
+	log("Debug Log was successfully destroyed", DebugMessageType::Info);
 	m_log_handler = nullptr;
 }
 
 void DebugLog::setLogHandler(function<void(std::string, DebugMessageType)> func)
 {
 	m_log_handler = func;
-	log("Debug Log was successfully created", DebugMessageType::INFO);
+	log("Debug Log was successfully created", DebugMessageType::Info);
 }
 
 /* Sends the Debug message to the client.
@@ -31,7 +31,7 @@ void DebugLog::log(ppvs::DebugMessage* msg)
 /* Sends the text to the client to display as debug output. The text should be a std::string object.
  * Before calling: make sure that the logging handler is deployed and bound.
  * */
-void DebugLog::log(std::string text, DebugMessageType severity = DebugMessageType::DEBUG)
+void DebugLog::log(std::string text, DebugMessageType severity = DebugMessageType::Debug)
 {
 	if (m_log_handler != NULL) {
 		m_log_handler(text, severity);

--- a/Puyolib/DebugLog.h
+++ b/Puyolib/DebugLog.h
@@ -18,6 +18,9 @@ enum class DebugMessageType {
 	DEBUG = 8
 };
 
+/* A more precise debug message class, might be used in exception handling and other scenarios
+ * where we don't want to handle raw strings.
+ * */
 class DebugMessage {
 public:
 	DebugMessage(std::basic_string<char> text, DebugMessageType severity = DebugMessageType::NONE) : m_text(text), m_severity(severity) {};
@@ -27,6 +30,13 @@ public:
 	DebugMessageType m_severity;
 };
 
+
+/* Puyolib debugging. This class allows a developer to send debug messages from Puyolib to the Client.
+ *
+ * A developer seeking to send a debug message to the client shall use the log method (under normal circumstances
+ * a member of ppvs::Game named m_debug) and call the log method with a std::string and
+ * an appropriate Debug Message type.
+ * */
 class DebugLog {
 public:
 	DebugLog() = default;

--- a/Puyolib/DebugLog.h
+++ b/Puyolib/DebugLog.h
@@ -14,11 +14,11 @@ namespace ppvs {
 using std::function;
 
 enum class DebugMessageType {
-	NONE = 0,
-	ERROR = 1,
-	WARNING = 2,
-	INFO = 4,
-	DEBUG = 8, // Without this exact comma the Visual C++ compiler will freak out...
+	None = 0,
+	Error = 1,
+	Warning = 2,
+	Info = 4,
+	Debug = 8, // Without this exact comma the Visual C++ compiler will freak out...
 };
 
 /* A more precise debug message class, might be used in exception handling and other scenarios
@@ -26,7 +26,7 @@ enum class DebugMessageType {
  * */
 class DebugMessage {
 public:
-	DebugMessage(std::string text, DebugMessageType severity = DebugMessageType::NONE) : m_text(text), m_severity(severity) {};
+	DebugMessage(std::string text, DebugMessageType severity = DebugMessageType::None) : m_text(text), m_severity(severity) {};
 	~DebugMessage() = default;
 
 	std::string m_text;

--- a/Puyolib/DebugLog.h
+++ b/Puyolib/DebugLog.h
@@ -18,7 +18,7 @@ enum class DebugMessageType {
 	ERROR = 1,
 	WARNING = 2,
 	INFO = 4,
-	DEBUG = 8
+	DEBUG = 8, // Without this exact comma the Visual C++ compiler will freak out...
 };
 
 /* A more precise debug message class, might be used in exception handling and other scenarios

--- a/Puyolib/DebugLog.h
+++ b/Puyolib/DebugLog.h
@@ -8,7 +8,10 @@
 #include <iostream>
 #include <functional>
 
+
 namespace ppvs {
+
+using std::function;
 
 enum class DebugMessageType {
 	NONE = 0,
@@ -23,7 +26,7 @@ enum class DebugMessageType {
  * */
 class DebugMessage {
 public:
-	DebugMessage(std::basic_string<char> text, DebugMessageType severity = DebugMessageType::NONE) : m_text(text), m_severity(severity) {};
+	DebugMessage(std::string text, DebugMessageType severity = DebugMessageType::NONE) : m_text(text), m_severity(severity) {};
 	~DebugMessage() = default;
 
 	std::string m_text;
@@ -44,11 +47,13 @@ public:
 
 	void log(DebugMessage *msg);
 	void log(std::string text, DebugMessageType severity);
+	// TODO: add support for logging with std::format strings and variable list once we switch to C++20
 
-	void setLogHandler(std::function<void(std::basic_string<char>,DebugMessageType)> f);
+
+	void setLogHandler(function<void(std::string,DebugMessageType)> f);
 
 private:
-	std::function<void(std::string,DebugMessageType)> m_log_handler;
+	function<void(std::string,DebugMessageType)> m_log_handler;
 
 
 };

--- a/Puyolib/DebugLog.h
+++ b/Puyolib/DebugLog.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2023, LossRain
+// SPDX-License-Identifier: GPLv3
+
+#pragma once
+
+#include <string>
+#include <deque>
+#include <iostream>
+#include <functional>
+
+namespace ppvs {
+
+enum class DebugMessageType {
+	NONE = 0,
+	ERROR = 1,
+	WARNING = 2,
+	INFO = 4,
+	DEBUG = 8
+};
+
+class DebugMessage {
+public:
+	DebugMessage(std::basic_string<char> text, DebugMessageType severity = DebugMessageType::NONE) : m_text(text), m_severity(severity) {};
+	~DebugMessage() = default;
+
+	std::string m_text;
+	DebugMessageType m_severity;
+};
+
+class DebugLog {
+public:
+	DebugLog() = default;
+	~DebugLog();
+
+	void log(DebugMessage *msg);
+	void log(std::string text, DebugMessageType severity);
+
+	void setLogHandler(std::function<void(std::basic_string<char>,DebugMessageType)> f);
+
+private:
+	std::function<void(std::string,DebugMessageType)> m_log_handler;
+
+
+};
+
+} // ppvs
+

--- a/Puyolib/Field.cpp
+++ b/Puyolib/Field.cpp
@@ -1364,7 +1364,8 @@ void Field::triggerGlow(PosVectorInt shadowPos[4], const int n, int colors[4])
 			// Error
 			shadowPos[i].x = -1;
 			shadowPos[i].y = -1;
-			debugString += "error";
+
+			m_player->m_currentGame->m_debug->log("Invalid shadow Puyo placement request",DebugMessageType::ERROR);
 		}
 	}
 

--- a/Puyolib/Field.cpp
+++ b/Puyolib/Field.cpp
@@ -1365,7 +1365,7 @@ void Field::triggerGlow(PosVectorInt shadowPos[4], const int n, int colors[4])
 			shadowPos[i].x = -1;
 			shadowPos[i].y = -1;
 
-			m_player->m_currentGame->m_debug->log("Invalid shadow Puyo placement request",DebugMessageType::ERROR);
+			m_player->m_currentGame->m_debug->log("Invalid shadow Puyo placement request",DebugMessageType::Error);
 		}
 	}
 

--- a/Puyolib/Game.cpp
+++ b/Puyolib/Game.cpp
@@ -59,6 +59,8 @@ Game::~Game()
 	delete m_statusFont;
 	delete m_data->front;
 	delete m_data;
+	delete m_debug;
+	m_debug = nullptr;
 }
 
 void Game::close()

--- a/Puyolib/Game.cpp
+++ b/Puyolib/Game.cpp
@@ -12,6 +12,8 @@
 
 namespace ppvs {
 
+using ppvs::DebugMessageType;
+
 void encode(const char* key, char* in, const int length)
 {
 	for (int i = 0; i < length; i++) {
@@ -60,7 +62,6 @@ Game::~Game()
 	delete m_data->front;
 	delete m_data;
 	delete m_debug;
-	m_debug = nullptr;
 }
 
 void Game::close()

--- a/Puyolib/Game.cpp
+++ b/Puyolib/Game.cpp
@@ -23,13 +23,11 @@ void encode(const char* key, char* in, const int length)
 
 Game* activeGame = nullptr;
 
-Game::Game(GameSettings* gs, DebugLog *dbg)
-	: m_settings(gs),
-	m_debug(dbg)
+Game::Game(GameSettings* gs, DebugLog* dbg)
+	: m_settings(gs)
+	, m_debug(dbg)
 {
 	initGlobal();
-
-
 
 	activeGame = this;
 	m_choiceTimer = (gs->rankedMatch == true ? 5 : 30) * 60;
@@ -135,6 +133,7 @@ void Game::loadGlobal()
 	m_data->playMusic = m_settings->playMusic;
 
 	m_statusFont = m_data->front->loadFont("Arial", 14);
+	m_debugFont = m_data->front->loadFont("Arial", 14);
 	setStatusText("");
 }
 
@@ -742,6 +741,13 @@ void Game::renderGame()
 		}
 	}
 
+	// Render debug text
+	updateDebugText();
+	if (m_debugText) {
+		m_data->front->setColor(255, 255, 255, 255);
+		m_debugText->draw(16, 0);
+	}
+
 	m_data->front->swapBuffers();
 }
 
@@ -755,6 +761,18 @@ void Game::setStatusText(const char* utf8)
 
 	m_statusText = m_statusFont->render(utf8);
 	m_lastText = utf8;
+}
+
+// Uses the status text font to render the current debug string
+void Game::updateDebugText()
+{
+	if (!m_debugFont)
+		return;
+	if (debugString.empty())
+		return;
+	delete m_debugText;
+
+	m_debugText = m_debugFont->render(debugString.c_str());
 }
 
 void Game::setWindowFocus(bool focus) const

--- a/Puyolib/Game.cpp
+++ b/Puyolib/Game.cpp
@@ -57,6 +57,7 @@ Game::~Game()
 	delete m_currentRuleSet;
 	delete m_statusText;
 	delete m_statusFont;
+	delete m_debugFont;
 	delete m_data->front;
 	delete m_data;
 	delete m_debug;

--- a/Puyolib/Game.cpp
+++ b/Puyolib/Game.cpp
@@ -21,10 +21,13 @@ void encode(const char* key, char* in, const int length)
 
 Game* activeGame = nullptr;
 
-Game::Game(GameSettings* gs)
-	: m_settings(gs)
+Game::Game(GameSettings* gs, DebugLog *dbg)
+	: m_settings(gs),
+	m_debug(dbg)
 {
 	initGlobal();
+
+
 
 	activeGame = this;
 	m_choiceTimer = (gs->rankedMatch == true ? 5 : 30) * 60;

--- a/Puyolib/Game.h
+++ b/Puyolib/Game.h
@@ -167,6 +167,11 @@ private:
 	FeText* m_statusText = nullptr;
 	std::string m_lastText;
 	void setStatusText(const char* utf8);
+	// TODO: add a debug status text manager and move it all out of this class
+	FeFont* m_debugFont = nullptr;
+	FeText* m_debugText = nullptr;
+	void updateDebugText();
+
 
 	bool m_playNext = true; // Helper variable for replays
 };

--- a/Puyolib/Game.h
+++ b/Puyolib/Game.h
@@ -112,7 +112,7 @@ public:
 	CharacterSelect* m_charSelectMenu = nullptr;
 	Menu* m_mainMenu = nullptr;
 	unsigned int m_randomSeedNextList = 0; // All players should use the same random seed
-	std::deque<std::string> m_debugMessages;
+	//std::deque<std::string> m_debugMessages;
 	bool m_forceStatusText = false;
 	TranslatableStrings m_translatableStrings {};
 

--- a/Puyolib/Game.h
+++ b/Puyolib/Game.h
@@ -9,6 +9,7 @@
 #include "RuleSet/RuleSet.h"
 #include "Sprite.h"
 #include "global.h"
+#include "DebugLog.h"
 #include <iostream>
 #include <string>
 
@@ -53,7 +54,7 @@ class Frontend;
 
 class Game {
 public:
-    explicit Game(GameSettings* gs);
+	explicit Game(GameSettings* gs, DebugLog *dbg);
 	~Game();
 
 	Game(const Game&) = delete;
@@ -72,13 +73,16 @@ public:
 	void renderGame();
 	void setWindowFocus(bool focus) const;
 	void setRules();
-    [[nodiscard]] bool isFever() const;
+	[[nodiscard]] bool isFever() const;
 
 	// Other
 	void checkEnd();
 	void addPlayer(PlayerType type, int playerNum, int numPlayers);
 	void resetPlayers();
-    [[nodiscard]] int getActivePlayers() const;
+	[[nodiscard]] int getActivePlayers() const;
+
+	// Debugging
+	DebugLog *m_debug = nullptr;
 
 	// Online
 	PVS_Client* m_network = nullptr;
@@ -86,12 +90,12 @@ public:
 	bool m_connected = false;
 	std::deque<NetworkMessage> m_messageCenter;
 	GameStatus m_currentGameStatus = GameStatus::WAITING;
-    [[nodiscard]] int countActivePlayers() const; // Do not confuse with "getActivePlayers()"
-    [[nodiscard]] int countBoundPlayers() const;
+	[[nodiscard]] int countActivePlayers() const; // Do not confuse with "getActivePlayers()"
+	[[nodiscard]] int countBoundPlayers() const;
 	bool m_stopChaining = false; // Set true to stop all players from chaining
-    [[nodiscard]] bool checkLowestId() const;
+	[[nodiscard]] bool checkLowestId() const;
 	void sendDescription() const;
-    [[nodiscard]] std::string sendUpdate() const; // Send the state of player 1 to update spectators
+	[[nodiscard]] std::string sendUpdate() const; // Send the state of player 1 to update spectators
 	int m_choiceTimer = 0;
 	int m_colorTimer = 10 * 60;
 	int m_activeAtStart = 0;

--- a/Puyolib/Player.cpp
+++ b/Puyolib/Player.cpp
@@ -584,8 +584,7 @@ void Player::play()
 {
 	// Debugging
 	if (debugMode == 1) {
-		if (m_playerNum == 1)
-			debugString = "";
+		debugString = "";
 		debugString += toString(static_cast<int>(m_currentPhase)) + "\n";
 		debugString += "garbage: " + toString(m_forgiveGarbage) + "\n";
 		if (m_activeGarbage == &m_normalGarbage)

--- a/Puyolib/global.cpp
+++ b/Puyolib/global.cpp
@@ -13,6 +13,18 @@
 namespace ppvs
 {
 
+// TODO: Define more granular debugging modes
+/* PUYOLIB DEBUGGING
+ * Define this compile flag to enable Puyolib debugging. This flag will display debug logging,
+ * debug status text and debug sprites. This might be augmented in the future.
+ * Alternatively, just set this variable to 1.
+ * */
+#ifdef PUYOLIB_DEBUG
+int debugMode = 1;
+#else
+int debugMode = 0;
+#endif
+
 // Strings
 const std::string kFolderUserSounds = "User/Sounds/";
 const std::string kFolderUserMusic = "User/Music/";
@@ -195,6 +207,5 @@ void initGlobal()
 }
 
 std::string debugString;
-int debugMode = 0;
 
 }

--- a/Puyolib/global.h
+++ b/Puyolib/global.h
@@ -174,10 +174,11 @@ double interpolate(std::string type, double startVal, double endVal, double t, d
 void splitString(std::string& in, char delimiter, StringList& v);
 void createFolder(std::string folderName);
 
-// Debugging
-extern FeFont* fontArial;
-extern std::string debugString;
+
+/* PUYOLIB DEBUGGING MODE
+ * See Puyolib/global.cpp for more info. */
 extern int debugMode;
+extern std::string debugString;
 
 // Convert int to string
 template <class T>


### PR DESCRIPTION
This request adds basic console output for all code with access to the ppvs::Game object in Puyolib, allowing easier debugging of internal Puyolib structures without a debugger.

This commit is client-agnostic as it allows any client to implement its own debug handling and uses std::string as a transport vehicle. Yet, this change might be breaking for ClientNG as I wasn't able to compile it successfully to test this scenario. 

There are currently no flags or methods to explicitly disable this information display outside of Qt's own switches.   