### PR TITLE
Puyolib: fix lose animations in Endless Fever

### DIFF
--- a/Puyolib/Player.cpp
+++ b/Puyolib/Player.cpp
@@ -1851,7 +1851,7 @@ void Player::checkWinner()
 void Player::setLose()
 {
 	m_currentGame->m_currentRuleSet->onLose(this);
-	m_characterAnimation.prepareAnimation("lose");
+	//m_characterAnimation.prepareAnimation("lose"); // moved to Phase 60
 
 	// Play lose sound sound
 	int activeplayers = 0;
@@ -1889,6 +1889,7 @@ void Player::loseGame()
 
 	if (m_loseWinTimer == 60) {
 		m_characterVoices.lose.play(m_data);
+		m_characterAnimation.prepareAnimation("lose");
 	}
 
 	// Online: wait for confirm message from everyone

--- a/Puyolib/Player.cpp
+++ b/Puyolib/Player.cpp
@@ -1851,7 +1851,6 @@ void Player::checkWinner()
 void Player::setLose()
 {
 	m_currentGame->m_currentRuleSet->onLose(this);
-	//m_characterAnimation.prepareAnimation("lose"); // moved to Phase 60
 
 	// Play lose sound sound
 	int activeplayers = 0;


### PR DESCRIPTION
In Endless Fever the character lose animation wouldn't show up if triggered by an expired timer or externally (lose is triggered by Player::loseGame() but setLose() is never called.)

Since Player::loseGame() seems to be called in all online, offline Tsu and EndlessFever I moved the animation playback there to fix the issue.