### PR TITLE
Automatically configure compile_commands.json by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ PuyoVS.pro.*
 /.direnv
 result
 result-*
+/compile_commands.json
+/.cache
 
 # Visual Studio
 .vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,17 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeModules/" ${CMAKE_MODULE_PATH}
 # Improves IDE support.
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+# Automatically set up compile_commands.json
+option(SETUP_COMPILE_COMMANDS "Automatically set up compile_commands.json" ON)
+if(SETUP_COMPILE_COMMANDS)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
+      ${CMAKE_BINARY_DIR}/compile_commands.json
+      ${CMAKE_CURRENT_SOURCE_DIR}/compile_commands.json
+  )
+endif()
+
 # Path setup.
 if(WIN32)
   if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)


### PR DESCRIPTION
When using an IDE like Qt Creator or Visual Studio this shouldn't really do anything, and it's OK if the command fails (e.g. on Windows with CMake <3.13 or without unprivileged symlinks enabled) but it is very useful for using e.g. vim or Visual Studio Code with clangd.