### PR TITLE
Ingame reloading of assets when changing settings

### DIFF
--- a/Client/gamemanager.cpp
+++ b/Client/gamemanager.cpp
@@ -700,6 +700,14 @@ void GameManager::rankedMatchmessageReceived(QString message)
 	}
 }
 
+void GameManager::hotReloadGameAssets()
+{
+	for (auto* widget: games) {
+		auto* game = widget->game();
+		game->hotReloadAssets();
+	}
+}
+
 bool GameManager::getGame(const QString& channel, ppvs::Game*& game, GameWidget*& widget) const
 {
 	if (channel.left(4) != "PVSM" && channel.left(4) != "PVST" && channel.left(4) != "PVSF")

--- a/Client/gamemanager.cpp
+++ b/Client/gamemanager.cpp
@@ -223,7 +223,7 @@ GameWidget* GameManager::createGame(ppvs::GameSettings* gs, const QString& roomN
 			QString("new|") + QString("%1|").arg(PVSVERSION) + QString(gs->ruleSetInfo.ruleSetType == ppvs::Rules::TSU_ONLINE ? "0" : "1"));
 	}
 
-	GameWidget* widget = new GameWidgetGL(game, proxy, audio, assetManagerTemplate->clone(), static_cast<QWidget*>(parent()));
+	GameWidget* widget = new GameWidgetGL(game, proxy, audio, assetManagerTemplate, static_cast<QWidget*>(parent()));
 	addGame(widget);
 
 	return widget;

--- a/Client/gamemanager.h
+++ b/Client/gamemanager.h
@@ -22,6 +22,7 @@ class GameAssetSettings;
 
 class GameManager : public QObject {
 	Q_OBJECT
+
 public:
 	explicit GameManager(NetClient* network, ppvs::AssetManager* am, QObject* parent = nullptr);
 	~GameManager() override;
@@ -39,6 +40,7 @@ public slots:
 	GameWidget* findGame(const QString& roomName) const;
 	void gameDestroyed(GameWidget* game);
 	bool rankedMatch() const;
+	void hotReloadGameAssets();
 
 private slots:
 	void channelJoined(QString channel, NetPeerList peers) const;

--- a/Client/gamewidget.cpp
+++ b/Client/gamewidget.cpp
@@ -48,6 +48,8 @@ GameWidget::GameWidget(ppvs::Game* game, NetChannelProxy* proxy, QWidget* parent
 	connect(mToggleChat, &QAction::toggled, this, &GameWidget::chatToggled);
 	connect(mFullScreen, &QAction::toggled, this, &GameWidget::fullScreenToggled);
 
+
+
 	setContextMenuPolicy(Qt::CustomContextMenu);
 	connect(this, &QWidget::customContextMenuRequested, this, &GameWidget::contextMenu);
 	if (mGame->m_settings->recording == ppvs::RecordState::REPLAYING) {

--- a/Client/gamewidgetgl.cpp
+++ b/Client/gamewidgetgl.cpp
@@ -115,7 +115,7 @@ GameWidgetGL::GameWidgetGL(ppvs::Game* game, NetChannelProxy* proxy, GameAudio* 
 	setAttribute(Qt::WA_DeleteOnClose);
 	d->ready = false;
 	d->audio = audio;
-    // TODO: possibly should use a smart pointer with a move here instead
+	// TODO: possibly should use a smart pointer with a move here instead
 	d->am = am;
 	d->inputDriver = ilib::getDriver();
 	d->inputDriver->enableEvents();
@@ -266,7 +266,12 @@ void GameWidgetGL::initialize()
 	d->gl->makeCurrent();
 	auto frontend = new FrontendGL(d->gl, d->audio, d->inputState, d->ext, this);
 
-	mGame->initGame(frontend, d->am);
+	// Generates the handler for obtaining assets
+	auto* am_render = d->am->generate_priv(frontend, mGame->m_debug);
+	am_render->activate(frontend, mGame->m_debug);
+	assert(am_render->is_activated());
+
+	mGame->initGame(frontend, am_render);
 	connect(frontend, &FrontendGL::musicStateChanged, this, &GameWidgetGL::setupMusic);
 	connect(frontend, &FrontendGL::musicVolumeChanged, this, &GameWidgetGL::changeMusicVolume);
 	glEnable(GL_TEXTURE_2D);

--- a/Client/gamewidgetgl.cpp
+++ b/Client/gamewidgetgl.cpp
@@ -158,7 +158,6 @@ GameWidgetGL::~GameWidgetGL()
 	d->inputDriver->disableEvents();
 
 	delete d->gl;
-	delete d->am;
 	delete d;
 
 	delete mGame;

--- a/Client/mainwindow.cpp
+++ b/Client/mainwindow.cpp
@@ -124,7 +124,7 @@ MainWindow::MainWindow(QWidget* parent)
 	// Update server list
 	updateServerList();
 
-	assetManagerTemplate = new ppvs::AssetManager(nullptr, nullptr);
+	assetManagerTemplate = new ppvs::AssetManager(nullptr);
 	initAssetManagerTemplate();
 
 	// Install game timer
@@ -1006,7 +1006,7 @@ ppvs::AssetBundle* MainWindow::generateFolderBundle(const QString& base_path)
 		assetSettings->characterSetup[ch] = characters.at(i).toStdString();
 	}
 
-	return new ppvs::FolderAssetBundle(nullptr, assetSettings);
+	return new ppvs::FolderAssetBundle(assetSettings);
 }
 
 ppvs::AssetBundle* MainWindow::generateDefaultBundle()
@@ -1022,7 +1022,7 @@ ppvs::AssetBundle* MainWindow::generateDefaultBundle()
 		auto ch = ppvs::PuyoCharacter(i);
 		assetSettings->characterSetup[ch] = "";
 	}
-	return new ppvs::FolderAssetBundle(nullptr, assetSettings);
+	return new ppvs::FolderAssetBundle(assetSettings);
 }
 
 void MainWindow::initAssetManagerTemplate()
@@ -1035,10 +1035,7 @@ void MainWindow::initAssetManagerTemplate()
 
 int MainWindow::refreshAssetManagerTemplate()
 {
-	assetManagerTemplate->deInit(); // Prevent others from reading AM
 	if (assetManagerTemplate != nullptr) {
-		assetManagerTemplate->unloadAll();
-		initAssetManagerTemplate();
 		return assetManagerTemplate->reloadBundles();
 	}
 	return 1;

--- a/Client/mainwindow.cpp
+++ b/Client/mainwindow.cpp
@@ -502,6 +502,12 @@ void MainWindow::on_SettingsDialog_Finished(int result)
 		}
 	}
 	showSettingsDlg = false;
+	refreshAssetManagerTemplate();
+	hotReloadGameAssets();
+}
+
+void MainWindow::hotReloadGameAssets() {
+	gameManager->hotReloadGameAssets();
 }
 
 void MainWindow::on_SearchDialog_Finished(int result)

--- a/Client/mainwindow.cpp
+++ b/Client/mainwindow.cpp
@@ -1005,8 +1005,7 @@ ppvs::AssetBundle* MainWindow::generateFolderBundle(const QString& base_path)
 		auto ch = ppvs::PuyoCharacter(i);
 		assetSettings->characterSetup[ch] = characters.at(i).toStdString();
 	}
-
-	return new ppvs::FolderAssetBundle(assetSettings);
+	return new ppvs::FolderAssetBundle(assetSettings, true);
 }
 
 ppvs::AssetBundle* MainWindow::generateDefaultBundle()
@@ -1022,7 +1021,7 @@ ppvs::AssetBundle* MainWindow::generateDefaultBundle()
 		auto ch = ppvs::PuyoCharacter(i);
 		assetSettings->characterSetup[ch] = "";
 	}
-	return new ppvs::FolderAssetBundle(assetSettings);
+	return new ppvs::FolderAssetBundle(assetSettings, false);
 }
 
 void MainWindow::initAssetManagerTemplate()
@@ -1036,7 +1035,17 @@ void MainWindow::initAssetManagerTemplate()
 int MainWindow::refreshAssetManagerTemplate()
 {
 	if (assetManagerTemplate != nullptr) {
-		return assetManagerTemplate->reloadBundles();
+		Settings& settings = pvsApp->settings();
+		auto* assetSettings = new ppvs::GameAssetSettings();
+		assetSettings->background = settings.string("custom", "background", "Forest").toUtf8().data();
+		assetSettings->puyo = settings.string("custom", "puyo", "Default").toUtf8().data();
+		assetSettings->sfx = settings.string("custom", "sound", "Default").toUtf8().data();
+		QStringList characters(settings.charMap());
+		for (int i = 0; i < characters.count(); i++) {
+			auto ch = ppvs::PuyoCharacter(i);
+			assetSettings->characterSetup[ch] = characters.at(i).toStdString();
+		}
+		return assetManagerTemplate->reloadBundles(assetSettings);
 	}
 	return 1;
 }

--- a/Client/mainwindow.h
+++ b/Client/mainwindow.h
@@ -75,7 +75,7 @@ protected:
 	void removeRankedFeverMatchRoom(NetChannel channel) const;
 	NetChannel selectedRankedFeverMatch() const;
 
-
+	// Reloads assets in all currently running Games
 	void hotReloadGameAssets();
 
 public slots:
@@ -89,6 +89,7 @@ public slots:
 	void on_OfflineDialog_Finished(int result);
 	void on_CreateChatroomDialog_Finished(CreateChatroomDialog*) const;
 
+	// Reloads available Asset Bundles and resets user preferences for affected bundles
 	int refreshAssetManagerTemplate();
 
 private slots:

--- a/Client/mainwindow.h
+++ b/Client/mainwindow.h
@@ -75,6 +75,9 @@ protected:
 	void removeRankedFeverMatchRoom(NetChannel channel) const;
 	NetChannel selectedRankedFeverMatch() const;
 
+
+	void hotReloadGameAssets();
+
 public slots:
 	void updateActions() const;
 	void updateJoinButton() const;

--- a/Client/settingsdialog.cpp
+++ b/Client/settingsdialog.cpp
@@ -298,6 +298,7 @@ void SettingsDialog::fetchFileLists()
 
 	// HACK: possible infinite loop, this will wait until the template AM is set to be initialized
 	// This is to prevent race conditions if a different thread manipulates the same object
+	assert(am_template->is_initialized());
 	while (!am_template->is_initialized())
 	{}
 

--- a/ClientNG/Scenes/Game/InGame.cpp
+++ b/ClientNG/Scenes/Game/InGame.cpp
@@ -88,7 +88,7 @@ ppvs::AssetManagerPriv* InGame::createAssetManager()
 	auto* defaultBundle = new ppvs::FolderAssetBundle(new ppvs::GameAssetSettings(m_game->m_settings));
 	manager->loadBundle(defaultBundle);
 
-	auto* priv = manager->generate_priv(m_frontend);
+	auto* priv = manager->generate_priv(m_frontend, nullptr);
 	priv->activate(m_frontend,nullptr);
 	return priv;
 }

--- a/ClientNG/Scenes/Game/InGame.cpp
+++ b/ClientNG/Scenes/Game/InGame.cpp
@@ -80,15 +80,17 @@ void InGame::draw()
 	m_target->present();
 }
 
-ppvs::AssetManager* InGame::createAssetManager()
+ppvs::AssetManagerPriv* InGame::createAssetManager()
 {
-	auto* manager = new ppvs::AssetManager(m_frontend, m_game->m_debug);
+	ppvs::AssetManager* manager = new ppvs::AssetManager(m_game->m_debug);
 	// TODO: add bundles automatically
 
-	auto* defaultBundle = new ppvs::FolderAssetBundle(m_frontend, new ppvs::GameAssetSettings(m_game->m_settings));
+	auto* defaultBundle = new ppvs::FolderAssetBundle(new ppvs::GameAssetSettings(m_game->m_settings));
 	manager->loadBundle(defaultBundle);
 
-	return manager;
+	auto* priv = manager->generate_priv(m_frontend);
+	priv->activate(m_frontend,nullptr);
+	return priv;
 }
 
 }

--- a/ClientNG/Scenes/Game/InGame.h
+++ b/ClientNG/Scenes/Game/InGame.h
@@ -30,7 +30,7 @@ public:
 	void update(double t) override;
 	void draw() override;
 
-	ppvs::AssetManager* createAssetManager();
+	ppvs::AssetManagerPriv* createAssetManager();
 
 private:
 	GameWindow& m_window;

--- a/Puyolib/AssetBundle.cpp
+++ b/Puyolib/AssetBundle.cpp
@@ -98,8 +98,8 @@ std::string TokenFnTranslator::token2fn(const std::string& token, PuyoCharacter 
 	return result;
 }
 
-FolderAssetBundle::FolderAssetBundle(Frontend* fe, ppvs::GameAssetSettings* folderLocations)
-	: AssetBundle(fe)
+FolderAssetBundle::FolderAssetBundle(ppvs::GameAssetSettings* folderLocations)
+	: AssetBundle()
 	, m_settings(folderLocations)
 {
 	m_translator = new TokenFnTranslator(folderLocations);
@@ -107,40 +107,30 @@ FolderAssetBundle::FolderAssetBundle(Frontend* fe, ppvs::GameAssetSettings* fold
 
 AssetBundle* FolderAssetBundle::clone()
 {
-	AssetBundle* new_bundle = new FolderAssetBundle(m_frontend, m_settings);
+	AssetBundle* new_bundle = new FolderAssetBundle(m_settings);
 	return new_bundle;
 }
 
-bool FolderAssetBundle::init(ppvs::Frontend* fe)
-{
-
-	if (!m_frontend) {
-		m_frontend = fe;
-		return false;
-	}
-	return true; // invalid call
-}
-
 // Loads the texture, returns whether the load was successful (for files, whether the file exists and loads)
-FeImage* FolderAssetBundle::loadImage(ImageToken token, std::string custom = "")
+FeImage* FolderAssetBundle::loadImage(ImageToken token, std::string custom, Frontend* frontend)
 {
-	return m_frontend->loadImage(m_translator->token2fn(token, custom));
+	return frontend->loadImage(m_translator->token2fn(token, custom));
 }
 
 // Loads the sound, returns whether the load was successful (for files, whether the file exists and loads)
-FeSound* FolderAssetBundle::loadSound(SoundEffectToken token, std::string custom)
+FeSound* FolderAssetBundle::loadSound(SoundEffectToken token, std::string custom, Frontend* frontend)
 {
-	return m_frontend->loadSound(m_translator->token2fn(token, custom));
+	return frontend->loadSound(m_translator->token2fn(token, custom));
 }
 
-FeImage* FolderAssetBundle::loadCharImage(ImageToken token, PuyoCharacter character)
+FeImage* FolderAssetBundle::loadCharImage(ImageToken token, PuyoCharacter character, Frontend* frontend)
 {
-	return m_frontend->loadImage(m_translator->token2fn(token, character));
+	return frontend->loadImage(m_translator->token2fn(token, character));
 }
 
-FeSound* FolderAssetBundle::loadCharSound(SoundEffectToken token, PuyoCharacter character)
+FeSound* FolderAssetBundle::loadCharSound(SoundEffectToken token, PuyoCharacter character, Frontend* frontend)
 {
-	return m_frontend->loadSound(m_translator->token2fn(token, character));
+	return frontend->loadSound(m_translator->token2fn(token, character));
 }
 
 bool isPossiblyAnimation(std::string fname, std::string script_name)

--- a/Puyolib/AssetBundle.cpp
+++ b/Puyolib/AssetBundle.cpp
@@ -29,7 +29,6 @@ TokenFnTranslator::TokenFnTranslator(ppvs::GameAssetSettings* aS)
 
 TokenFnTranslator::~TokenFnTranslator() = default;
 
-
 void TokenFnTranslator::reload()
 {
 	specialTokens = {
@@ -38,19 +37,30 @@ void TokenFnTranslator::reload()
 		{ "%background%", kFolderUserBackgrounds + "/" + gameSettings->background },
 		{ "%puyo%", kFolderUserPuyo + "/" + gameSettings->puyo },
 		{ "%sfx%", gameSettings->sfx },
-		{ "%usersounds%", kFolderUserSounds},
-		{ "%charsetup%", kFolderUserCharacter  }
+		{ "%usersounds%", kFolderUserSounds },
+		{ "%charsetup%", kFolderUserCharacter }
 		// { "%custom%", custom_value } // Specifier for menus, animations
 	};
 }
-std::string TokenFnTranslator::token2fn(const SoundEffectToken token, const std::string& custom) {
-	return token2fn(sndTokenToPseudoFn[token],custom);
+
+void TokenFnTranslator::reload(GameAssetSettings* settings)
+{
+	settings->baseAssetDir = gameSettings->baseAssetDir; // Keep current folder location
+	gameSettings = settings;
+	reload();
 }
-std::string TokenFnTranslator::token2fn(const ImageToken token, const std::string& custom) {
-	return token2fn(imgTokenToPseudoFn[token],custom);
+
+std::string TokenFnTranslator::token2fn(const SoundEffectToken token, const std::string& custom)
+{
+	return token2fn(sndTokenToPseudoFn[token], custom);
 }
-std::string TokenFnTranslator::token2fn(const AnimationToken token, const std::string& custom) {
-	return token2fn(animTokenToPseudoFn[token],custom);
+std::string TokenFnTranslator::token2fn(const ImageToken token, const std::string& custom)
+{
+	return token2fn(imgTokenToPseudoFn[token], custom);
+}
+std::string TokenFnTranslator::token2fn(const AnimationToken token, const std::string& custom)
+{
+	return token2fn(animTokenToPseudoFn[token], custom);
 }
 
 std::string TokenFnTranslator::token2fn(const std::string& token, const std::string& custom)
@@ -74,14 +84,17 @@ std::string TokenFnTranslator::token2fn(const std::string& token, const std::str
 	return result;
 }
 // FIXME: duplicated code
-std::string TokenFnTranslator::token2fn(const SoundEffectToken token, const  PuyoCharacter character) {
-	return token2fn(sndTokenToPseudoFn[token],character);
+std::string TokenFnTranslator::token2fn(const SoundEffectToken token, const PuyoCharacter character)
+{
+	return token2fn(sndTokenToPseudoFn[token], character);
 }
-std::string TokenFnTranslator::token2fn(const ImageToken token, const  PuyoCharacter character) {
-	return token2fn(imgTokenToPseudoFn[token],character);
+std::string TokenFnTranslator::token2fn(const ImageToken token, const PuyoCharacter character)
+{
+	return token2fn(imgTokenToPseudoFn[token], character);
 }
-std::string TokenFnTranslator::token2fn(const AnimationToken token, const  PuyoCharacter character) {
-	return token2fn(animTokenToPseudoFn[token],character);
+std::string TokenFnTranslator::token2fn(const AnimationToken token, const PuyoCharacter character)
+{
+	return token2fn(animTokenToPseudoFn[token], character);
 }
 
 std::string TokenFnTranslator::token2fn(const std::string& token, PuyoCharacter character)
@@ -98,17 +111,23 @@ std::string TokenFnTranslator::token2fn(const std::string& token, PuyoCharacter 
 	return result;
 }
 
-FolderAssetBundle::FolderAssetBundle(ppvs::GameAssetSettings* folderLocations)
+FolderAssetBundle::FolderAssetBundle(ppvs::GameAssetSettings* folderLocations, bool is_user_defined)
 	: AssetBundle()
 	, m_settings(folderLocations)
 {
 	m_translator = new TokenFnTranslator(folderLocations);
+	user_defined = is_user_defined;
 }
 
 AssetBundle* FolderAssetBundle::clone()
 {
 	AssetBundle* new_bundle = new FolderAssetBundle(m_settings);
 	return new_bundle;
+}
+
+bool FolderAssetBundle::affectedByUser()
+{
+	return user_defined;
 }
 
 // Loads the texture, returns whether the load was successful (for files, whether the file exists and loads)
@@ -152,12 +171,10 @@ std::string FolderAssetBundle::getAnimationFolder(AnimationToken token, std::str
 	return isPossiblyAnimation(dir, script_name) ? dir : "";
 }
 
-void FolderAssetBundle::reload(Frontend* fe)
+void FolderAssetBundle::reload(GameAssetSettings* settings)
 {
-	if (fe) {
-		m_frontend = fe;
-	}
-	m_translator->reload();
+	assert(user_defined);
+	m_translator->reload(settings);
 }
 
 void FolderAssetBundle::reload()

--- a/Puyolib/AssetBundle.h
+++ b/Puyolib/AssetBundle.h
@@ -285,19 +285,15 @@ private:
 class AssetBundle {
 public:
 	AssetBundle() = default;
-	explicit AssetBundle(Frontend* fe)
-		: m_frontend(fe) {};
 	virtual ~AssetBundle() = default;
 	virtual AssetBundle* clone() = 0;
 
-	// Gives this bundle a Frontend, usually binding it to a particular game
-	virtual bool init(Frontend* fe) = 0;
 
-	virtual FeImage* loadImage(ImageToken token, std::string custom) = 0;
-	virtual FeSound* loadSound(SoundEffectToken token, std::string custom) = 0;
+	virtual FeImage* loadImage(ImageToken token, std::string custom, Frontend* frontend) = 0;
+	virtual FeSound* loadSound(SoundEffectToken token, std::string custom, Frontend* frontend) = 0;
 
-	virtual FeImage* loadCharImage(ImageToken token, PuyoCharacter character) = 0;
-	virtual FeSound* loadCharSound(SoundEffectToken token, PuyoCharacter character) = 0;
+	virtual FeImage* loadCharImage(ImageToken token, PuyoCharacter character, Frontend* frontend) = 0;
+	virtual FeSound* loadCharSound(SoundEffectToken token, PuyoCharacter character, Frontend* frontend) = 0;
 	virtual std::string getCharAnimationsFolder(PuyoCharacter character) = 0;
 	virtual std::string getAnimationFolder(AnimationToken token, std::string script_name) = 0;
 
@@ -319,17 +315,16 @@ protected:
 
 class FolderAssetBundle : public AssetBundle {
 public:
-	FolderAssetBundle(Frontend* fe, GameAssetSettings* folderLocations);
+	FolderAssetBundle(ppvs::GameAssetSettings* folderLocations);
 	~FolderAssetBundle() override = default;
 
 	AssetBundle* clone() override;
-	bool init(Frontend* fe) override;
 
-	FeImage* loadImage(ImageToken token, std::string custom) override;
-	FeSound* loadSound(SoundEffectToken token, std::string custom) override;
+	FeImage* loadImage(ImageToken token, std::string custom, Frontend* frontend) override;
+	FeSound* loadSound(SoundEffectToken token, std::string custom, Frontend* frontend) override;
 
-	FeImage* loadCharImage(ImageToken token, PuyoCharacter character) override;
-	FeSound* loadCharSound(SoundEffectToken token, PuyoCharacter character) override;
+	FeImage* loadCharImage(ImageToken token, PuyoCharacter character, Frontend* frontend) override;
+	FeSound* loadCharSound(SoundEffectToken token, PuyoCharacter character, Frontend* frontend) override;
 
 	// Returns "" if invalid, otherwise a possible candidate for animation
 	std::string getCharAnimationsFolder(PuyoCharacter character) override;

--- a/Puyolib/AssetBundle.h
+++ b/Puyolib/AssetBundle.h
@@ -133,6 +133,7 @@ public:
 	~TokenFnTranslator();
 
 	void reload();
+	void reload(GameAssetSettings* settings);
 
 	// For regular (global) tokens
 	std::string token2fn(const std::string& token, const std::string& custom = "");
@@ -140,11 +141,10 @@ public:
 	std::string token2fn(ImageToken token, const std::string& custom = "");
 	std::string token2fn(AnimationToken token, const std::string& custom = "");
 	// For character-specific tokens
-	std::string token2fn(const std::string& token,  PuyoCharacter character);
+	std::string token2fn(const std::string& token, PuyoCharacter character);
 	std::string token2fn(SoundEffectToken token, PuyoCharacter character);
 	std::string token2fn(ImageToken token, PuyoCharacter character);
 	std::string token2fn(AnimationToken token, PuyoCharacter character);
-
 
 	DebugLog* m_debug {};
 
@@ -288,7 +288,6 @@ public:
 	virtual ~AssetBundle() = default;
 	virtual AssetBundle* clone() = 0;
 
-
 	virtual FeImage* loadImage(ImageToken token, std::string custom, Frontend* frontend) = 0;
 	virtual FeSound* loadSound(SoundEffectToken token, std::string custom, Frontend* frontend) = 0;
 
@@ -303,19 +302,23 @@ public:
 	virtual std::list<std::string> listCharacterSkins() = 0;
 
 	virtual void reload() = 0;
-	// Reloads this bundle and gives it a Frontend, usually binding it to a particular game
-	virtual void reload(Frontend* fe) = 0;
+	// Reloads this bundle and feed it GameAssetSettings, usually forcing user settings
+	virtual void reload(GameAssetSettings* settings) = 0;
+
+	virtual bool affectedByUser() = 0;
 
 	bool active = false;
+
 	DebugLog* m_debug {};
 
 protected:
 	Frontend* m_frontend {};
+	bool user_defined = true;
 };
 
 class FolderAssetBundle : public AssetBundle {
 public:
-	FolderAssetBundle(ppvs::GameAssetSettings* folderLocations);
+	FolderAssetBundle(ppvs::GameAssetSettings* folderLocations, bool is_user_defined = true);
 	~FolderAssetBundle() override = default;
 
 	AssetBundle* clone() override;
@@ -336,9 +339,12 @@ public:
 	std::list<std::string> listCharacterSkins() override;
 
 	void reload() override;
-	void reload(Frontend* fe) override;
+	void reload(GameAssetSettings* settings) override;
 
-private:
+	bool affectedByUser() override;
+
+protected:
+	bool user_defined;
 	TokenFnTranslator* m_translator {};
 	GameAssetSettings* m_settings {};
 };

--- a/Puyolib/AssetManager.cpp
+++ b/Puyolib/AssetManager.cpp
@@ -41,7 +41,6 @@ AssetManager::~AssetManager()
 
 bool AssetManager::loadBundle(AssetBundle* bundle, int priority)
 {
-	// bundle->init(m_front);
 	bundle->reload();
 	bundle->m_debug = m_debug;
 	// TODO: implement priority
@@ -198,11 +197,25 @@ bool AssetManager::reloadBundles()
 {
 	int number_of_loaded = 0;
 	for (auto bundle : m_bundleList) {
+		assert(bundle!= nullptr);
 		bundle->reload();
 		number_of_loaded++;
 	}
 	return number_of_loaded;
 }
+bool AssetManager::reloadBundles(GameAssetSettings* settings) {
+	int number_of_loaded = 0;
+	for (auto bundle: m_bundleList) {
+		assert(bundle!= nullptr);
+		if (bundle->affectedByUser()) {
+			bundle->reload(settings);
+			number_of_loaded++;
+		}
+	}
+	assert(number_of_loaded);
+	return number_of_loaded;
+}
+
 AssetManagerPriv::AssetManagerPriv(AssetManager* parent, Frontend* frontend, DebugLog* dbg)
 	: own_parent(parent)
 	, m_frontend(frontend)

--- a/Puyolib/AssetManager.cpp
+++ b/Puyolib/AssetManager.cpp
@@ -5,19 +5,24 @@
 
 namespace ppvs {
 
-AssetManager* AssetManager::clone()
+AssetManagerPriv* AssetManager::generate_priv(Frontend* frontend)
 {
-	auto* current = new AssetManager;
+	/*auto* current = new AssetManager;
 	for (auto bundle : m_bundleList) {
-		current->loadBundle(bundle->clone());
+	    current->loadBundle(bundle->clone());
 	}
-	current->activate(m_front, m_debug);
-	return current;
+	//current->activate(m_front, m_debug);
+	//return current;*/
+
+	return new AssetManagerPriv(this, frontend, m_debug);
+}
+AssetManagerPriv* AssetManager::generate_priv(Frontend* frontend, DebugLog* dbg)
+{
+	return new AssetManagerPriv(this, frontend, dbg);
 }
 
-AssetManager::AssetManager(ppvs::Frontend* fe, DebugLog* dbg)
-	: m_front(fe)
-	, m_debug(dbg)
+AssetManager::AssetManager(DebugLog* dbg)
+	: m_debug(dbg)
 {
 	if (m_debug != nullptr) {
 		m_debug->log("Asset manager loaded", DebugMessageType::Debug);
@@ -34,22 +39,9 @@ AssetManager::~AssetManager()
 	}
 }
 
-void AssetManager::activate(ppvs::Frontend* fe, ppvs::DebugLog* debug)
-{
-	m_front = fe;
-	m_debug = debug;
-	reloadBundles();
-	// Do not activate unless we know we won't call nullptr
-	if (m_front != nullptr && m_debug != nullptr) {
-		activated = true;
-	} else {
-		activated = false;
-	}
-}
-
 bool AssetManager::loadBundle(AssetBundle* bundle, int priority)
 {
-	bundle->init(m_front);
+	// bundle->init(m_front);
 	bundle->reload();
 	bundle->m_debug = m_debug;
 	// TODO: implement priority
@@ -81,41 +73,35 @@ bool AssetManager::unloadAll()
 	return false;
 }
 
-FeImage* AssetManager::loadImage(const ImageToken token, const std::string& custom)
+FeImage* AssetManager::loadImage(ImageToken token, const std::string& custom, Frontend* frontend)
 {
 	FeImage* target {};
 	for (auto* bundle : m_bundleList) {
-		target = bundle->loadImage(token, custom);
+		target = bundle->loadImage(token, custom, frontend);
 		if (target != nullptr && !target->error()) {
 			break;
 		}
 	}
-	if (target == nullptr || target->error()) {
-		m_debug->log("Error loading image token " + toString(static_cast<int>(token)) + " custom " + custom, DebugMessageType::Error);
-	}
 	return target;
 }
 
-FeImage* AssetManager::loadImage(const ImageToken token, PuyoCharacter character)
+FeImage* AssetManager::loadImage(const ImageToken token, PuyoCharacter character, Frontend* frontend)
 {
 	FeImage* target {};
 	for (auto* bundle : m_bundleList) {
-		target = bundle->loadCharImage(token, character);
+		target = bundle->loadCharImage(token, character, frontend);
 		if (target != nullptr && !target->error()) {
 			break;
 		}
 	}
-	if (target == nullptr || target->error()) {
-		m_debug->log("Error loading image token " + toString(static_cast<int>(token)) + " character " + std::to_string(static_cast<int>(character)), DebugMessageType::Error);
-	}
 	return target;
 }
 
-FeSound* AssetManager::loadSound(const SoundEffectToken token, const std::string& custom)
+FeSound* AssetManager::loadSound(const SoundEffectToken token, const std::string& custom, Frontend* frontend)
 {
 	FeSound* target = {};
 	for (auto* bundle : m_bundleList) {
-		target = bundle->loadSound(token, custom);
+		target = bundle->loadSound(token, custom, frontend);
 		if (!target->error()) {
 			// target->play();
 			break;
@@ -123,25 +109,19 @@ FeSound* AssetManager::loadSound(const SoundEffectToken token, const std::string
 			target = nullptr;
 		}
 	}
-	if (target == nullptr || target->error()) {
-		m_debug->log("Error loading sound token " + toString(static_cast<int>(token)) + " custom " + custom, DebugMessageType::Error);
-	}
 	return target;
 }
 
-FeSound* AssetManager::loadSound(const SoundEffectToken token, PuyoCharacter character)
+FeSound* AssetManager::loadSound(const SoundEffectToken token, PuyoCharacter character, Frontend* frontend)
 {
 	FeSound* target = {};
 	for (auto* bundle : m_bundleList) {
-		target = bundle->loadCharSound(token, character);
+		target = bundle->loadCharSound(token, character, frontend);
 		if (!target->error()) {
 			break;
 		} else {
 			target = nullptr;
 		}
-	}
-	if (target == nullptr || target->error()) {
-		m_debug->log("Error loading sound token " + toString(static_cast<int>(token)) + " character " + std::to_string(static_cast<int>(character)), DebugMessageType::Error);
 	}
 	return target;
 }
@@ -155,9 +135,6 @@ std::string AssetManager::getAnimationFolder(ppvs::PuyoCharacter character)
 			break;
 		}
 	}
-	if (target.empty()) {
-		m_debug->log("Error loading animation script character " + std::to_string(static_cast<int>(character)), DebugMessageType::Error);
-	}
 	return target;
 }
 
@@ -169,9 +146,6 @@ std::string AssetManager::getAnimationFolder(AnimationToken token, const std::st
 		if (!target.empty()) {
 			break;
 		}
-	}
-	if (target.empty()) {
-		m_debug->log("Error loading animation script token " + toString(static_cast<int>(token)), DebugMessageType::Error);
 	}
 	return target;
 }
@@ -224,10 +198,95 @@ bool AssetManager::reloadBundles()
 {
 	int number_of_loaded = 0;
 	for (auto bundle : m_bundleList) {
-		bundle->reload(m_front);
+		bundle->reload();
 		number_of_loaded++;
 	}
 	return number_of_loaded;
+}
+AssetManagerPriv::AssetManagerPriv(AssetManager* parent, Frontend* frontend, DebugLog* dbg)
+	: own_parent(parent)
+	, m_frontend(frontend)
+	, m_debug(dbg)
+{
+	allow_loading();
+};
+
+void AssetManagerPriv::activate(ppvs::Frontend* fe, ppvs::DebugLog* debug)
+{
+	m_frontend = fe;
+	m_debug = debug;
+	// Do not activate unless we know we won't call nullptr
+	if (m_frontend != nullptr && m_debug != nullptr) {
+		activated = true;
+	} else {
+		activated = false;
+	}
+}
+
+// Attempts to load the image with the token (see FolderAssetBundle in AssetBundle.h)
+// parameter `custom` will replace %custom% tag in pseudo-filename
+FeImage* AssetManagerPriv::loadImage(ImageToken token, const std::string& custom)
+{
+	while (load_lock) { };
+	auto* target = own_parent->loadImage(token, custom, m_frontend);
+	if (target == nullptr || target->error()) {
+		m_debug->log("Error loading image token " + toString(static_cast<int>(token)) + " custom " + custom, DebugMessageType::Error);
+	}
+	return target;
+}
+
+// Attempts to load the sound with the token (see FolderAssetBundle in AssetBundle.h)
+// parameter `custom` will replace %custom% tag in pseudo-filename
+FeSound* AssetManagerPriv::loadSound(SoundEffectToken token, const std::string& custom)
+{
+	while (load_lock) { };
+	auto* target = own_parent->loadSound(token, custom, m_frontend);
+	if (target == nullptr || target->error()) {
+		m_debug->log("Error loading sound token " + toString(static_cast<int>(token)) + " custom " + custom, DebugMessageType::Error);
+	}
+	return target;
+}
+
+// Attempts to load the character-based image with the token (see FolderAssetBundle in AssetBundle.h)
+FeImage* AssetManagerPriv::loadImage(ImageToken token, PuyoCharacter character)
+{
+	while (load_lock) { };
+	auto* target = own_parent->loadImage(token, character, m_frontend);
+	if (target == nullptr || target->error()) {
+		m_debug->log("Error loading image token " + toString(static_cast<int>(token)) + " character " + std::to_string(static_cast<int>(character)), DebugMessageType::Error);
+	}
+	return target;
+};
+// Attempts to load the character-based sound with the token (see FolderAssetBundle in AssetBundle.h)
+FeSound* AssetManagerPriv::loadSound(SoundEffectToken token, PuyoCharacter character)
+{
+	while (load_lock) { };
+	auto* target = own_parent->loadSound(token, character, m_frontend);
+	if (target == nullptr || target->error()) {
+		m_debug->log("Error loading sound token " + toString(static_cast<int>(token)) + " character " + std::to_string(static_cast<int>(character)), DebugMessageType::Error);
+	}
+	return target;
+};
+
+// Attempts to locate a viable folder for animation files
+// Takes a token and filename of script
+std::string AssetManagerPriv::getAnimationFolder(AnimationToken token, const std::string& script_name)
+{
+	auto target = own_parent->getAnimationFolder(token, script_name);
+	if (target.empty()) {
+		m_debug->log("Error loading animation script token " + toString(static_cast<int>(token)), DebugMessageType::Error);
+	}
+	return target;
+}
+// Attempts to locate a viable folder for animation files
+// Takes a character, setup is assumed
+std::string AssetManagerPriv::getAnimationFolder(ppvs::PuyoCharacter character)
+{
+	auto target = own_parent->getAnimationFolder(character);
+	if (target.empty()) {
+		m_debug->log("Error loading animation script character " + toString(static_cast<int>(character)), DebugMessageType::Error);
+	}
+	return target;
 }
 
 } // ppvs

--- a/Puyolib/AssetManager.cpp
+++ b/Puyolib/AssetManager.cpp
@@ -5,20 +5,9 @@
 
 namespace ppvs {
 
-AssetManagerPriv* AssetManager::generate_priv(Frontend* frontend)
-{
-	/*auto* current = new AssetManager;
-	for (auto bundle : m_bundleList) {
-	    current->loadBundle(bundle->clone());
-	}
-	//current->activate(m_front, m_debug);
-	//return current;*/
-
-	return new AssetManagerPriv(this, frontend, m_debug);
-}
 AssetManagerPriv* AssetManager::generate_priv(Frontend* frontend, DebugLog* dbg)
 {
-	return new AssetManagerPriv(this, frontend, dbg);
+	return new AssetManagerPriv(this, frontend, dbg ? dbg : m_debug);
 }
 
 AssetManager::AssetManager(DebugLog* dbg)

--- a/Puyolib/AssetManager.h
+++ b/Puyolib/AssetManager.h
@@ -57,6 +57,10 @@ public:
 	// Assumes that you still have access to the setup data objects of each bundle
 	bool reloadBundles();
 
+	// Reloads the setup of all available bundles while overwriting user settings for all bundles
+	// TODO: allow special bundles not to be affected
+	bool reloadBundles(GameAssetSettings* settings);
+
 	// Iterators for menus
 	std::set<std::string> listPuyoSkins();
 	std::set<std::string> listBackgrounds();

--- a/Puyolib/AssetManager.h
+++ b/Puyolib/AssetManager.h
@@ -18,8 +18,7 @@ public:
 	AssetManager(DebugLog* dbg);
 	~AssetManager();
 
-	// Creates an unactivated clone of the current manager
-	AssetManagerPriv* generate_priv(Frontend* frontend);
+	// Creates a rendering agent for the Manager
 	AssetManagerPriv* generate_priv(Frontend* frontend, DebugLog* m_dbg);
 
 	// Initialized means that all bundles are loaded and is safe to refer to

--- a/Puyolib/AssetManager.h
+++ b/Puyolib/AssetManager.h
@@ -7,29 +7,26 @@
 #include "DebugLog.h"
 #include "Frontend.h"
 #include "GameSettings.h"
+#include <atomic>
 #include <set>
 #include <string>
 namespace ppvs {
-
+class AssetManagerPriv;
 class AssetManager {
 public:
 	AssetManager();
-	AssetManager(Frontend* fe, DebugLog* dbg);
+	AssetManager(DebugLog* dbg);
 	~AssetManager();
 
 	// Creates an unactivated clone of the current manager
-	AssetManager* clone();
+	AssetManagerPriv* generate_priv(Frontend* frontend);
+	AssetManagerPriv* generate_priv(Frontend* frontend, DebugLog* m_dbg);
 
 	// Initialized means that all bundles are loaded and is safe to refer to
 	// Here mostly for thread safety of Client
-	void init() {initialized=true;};
-	void deInit() {initialized=false;};
-	bool is_initialized() const {return initialized;};
-
-	// Activation means that it's being used in a particular game
-	void activate(Frontend* fe, DebugLog* dbg);
-	void deactivate() {activated=false;};
-	bool is_activated() const {return activated;};
+	void init() { initialized = true; };
+	void deInit() { initialized = false; };
+	bool is_initialized() const { return initialized; };
 
 	// Bundle management
 	bool loadBundle(AssetBundle* bundle, int priority = 0); // adds Bundle, assigns Frontend
@@ -38,16 +35,16 @@ public:
 
 	// Attempts to load the image with the token (see FolderAssetBundle in AssetBundle.h)
 	// parameter `custom` will replace %custom% tag in pseudo-filename
-	FeImage* loadImage(ImageToken token,const std::string& custom = "");
+	FeImage* loadImage(ImageToken token, const std::string& custom = "", Frontend* frontend = nullptr);
 
 	// Attempts to load the sound with the token (see FolderAssetBundle in AssetBundle.h)
 	// parameter `custom` will replace %custom% tag in pseudo-filename
-	FeSound* loadSound(SoundEffectToken token,const std::string& custom = "");
+	FeSound* loadSound(SoundEffectToken token, const std::string& custom = "", Frontend* frontend = nullptr);
 
 	// Attempts to load the character-based image with the token (see FolderAssetBundle in AssetBundle.h)
-	FeImage* loadImage(ImageToken token, PuyoCharacter character);
+	FeImage* loadImage(ImageToken token, PuyoCharacter character, Frontend* frontend = nullptr);
 	// Attempts to load the character-based sound with the token (see FolderAssetBundle in AssetBundle.h)
-	FeSound* loadSound(SoundEffectToken token, PuyoCharacter character);
+	FeSound* loadSound(SoundEffectToken token, PuyoCharacter character, Frontend* frontend = nullptr);
 
 	// Attempts to locate a viable folder for animation files
 	// Takes a token and filename of script
@@ -66,13 +63,57 @@ public:
 	std::set<std::string> listSfx();
 	std::set<std::string> listCharacterSkins();
 
-
 protected:
 	std::list<AssetBundle*> m_bundleList;
-	Frontend* m_front{};
-	DebugLog* m_debug{};
-	bool activated = false;
+	DebugLog* m_debug {};
 	bool initialized = false;
+};
+
+class AssetManagerPriv {
+public:
+	AssetManagerPriv(AssetManager* parent, Frontend* frontend, DebugLog* dbg = nullptr) ;
+	~AssetManagerPriv();
+
+	// Activation means that it's being used in a particular game
+	void activate(Frontend* fe, DebugLog* dbg);
+	void deactivate() { activated = false; };
+	bool is_activated() const { return activated; };
+
+	// Attempts to load the image with the token (see FolderAssetBundle in AssetBundle.h)
+	// parameter `custom` will replace %custom% tag in pseudo-filename
+	FeImage* loadImage(ImageToken token, const std::string& custom = "");
+
+	// Attempts to load the sound with the token (see FolderAssetBundle in AssetBundle.h)
+	// parameter `custom` will replace %custom% tag in pseudo-filename
+	FeSound* loadSound(SoundEffectToken token, const std::string& custom = "");
+
+	// Attempts to load the character-based image with the token (see FolderAssetBundle in AssetBundle.h)
+	FeImage* loadImage(ImageToken token, PuyoCharacter character);
+	// Attempts to load the character-based sound with the token (see FolderAssetBundle in AssetBundle.h)
+	FeSound* loadSound(SoundEffectToken token, PuyoCharacter character);
+
+	// Attempts to locate a viable folder for animation files
+	// Takes a token and filename of script
+	std::string getAnimationFolder(AnimationToken token, const std::string& script_name = "animation.xml");
+	// Attempts to locate a viable folder for animation files
+	// Takes a character, setup is assumed
+	std::string getAnimationFolder(ppvs::PuyoCharacter character);
+
+	// (Dis)allows any external object to load any assets.
+	void disallow_loading()
+	{
+		while (load_lock.exchange(true)) { };
+	};
+	void allow_loading() { load_lock.store(false); };
+
+private:
+	AssetManager* own_parent;
+	Frontend* m_frontend;
+	DebugLog* m_debug;
+
+	bool activated;
+
+	std::atomic<bool> load_lock = { false };
 };
 
 } // ppvs

--- a/Puyolib/CharacterSelect.cpp
+++ b/Puyolib/CharacterSelect.cpp
@@ -51,6 +51,26 @@ CharacterSelect::~CharacterSelect()
 	delete[] m_madeChoice;
 }
 
+void CharacterSelect::hotRedraw()
+{
+	constexpr int height = 3;
+	for (int i = 0; i < height; i++) {
+		constexpr int width = 8;
+		for (int j = 0; j < width; j++) {
+			m_holder[i * width + j].setImage(m_data->imgCharHolder);
+			m_holder[i * width + j].setCenter(0, 0);
+			m_holder[i * width + j].setPosition(
+				static_cast<float>(64 + j * 66),
+				static_cast<float>(64 + i * 52));
+			m_charSprite[i * width + j].setImage(m_currentGame->m_assetManager->loadImage(ImageToken::imgCharIcon, m_order[i * width + j]));
+			m_charSprite[i * width + j].setCenter(0, 0);
+			m_charSprite[i * width + j].setPosition(
+				static_cast<float>(64 + j * 66 + 1),
+				static_cast<float>(64 + i * 52 + 1));
+		}
+	}
+}
+
 void CharacterSelect::draw()
 {
 	// Set colors

--- a/Puyolib/CharacterSelect.h
+++ b/Puyolib/CharacterSelect.h
@@ -16,6 +16,7 @@ public:
 	CharacterSelect& operator=(const CharacterSelect&) = delete;
 	CharacterSelect(CharacterSelect&&) = delete;
 	CharacterSelect& operator=(CharacterSelect&&) = delete;
+	void hotRedraw();
 
 	void draw();
 	void prepare();

--- a/Puyolib/Field.cpp
+++ b/Puyolib/Field.cpp
@@ -649,6 +649,32 @@ void Field::draw() const
 	drawField();
 }
 
+void Field::hotReload() {
+	for (int i = 0; i < m_properties.gridX; i++) {
+		for (int j = 0; j < m_properties.gridY; j++) {
+			if (isPuyo(i, j)) {
+				m_fieldPuyoArray[i][j]->reloadSprite();
+			}
+		}
+	}
+
+	// Draw deleting puyo
+	for (const auto puyo : m_deletedPuyo) {
+		puyo->reloadSprite();
+	}
+
+	// Draw particles on the field
+	for (const auto particle : m_particles) {
+		particle->reload();
+	}
+
+	// Draw throwPuyo on the field
+	for (const auto particleThrow : m_particlesThrow) {
+		particleThrow->reload();
+	}
+
+}
+
 //============================
 // Game-play related functions
 //============================

--- a/Puyolib/Field.h
+++ b/Puyolib/Field.h
@@ -62,6 +62,7 @@ public:
 	void setVisible(bool);
 	void drawField() const;
 	void draw() const;
+	void hotReload();
 
 	// Game-play related functions
 	void createPuyo(); // Phase 20

--- a/Puyolib/Game.cpp
+++ b/Puyolib/Game.cpp
@@ -406,6 +406,18 @@ void Game::setRules()
 	}
 }
 
+void Game::hotReloadAssets() {
+	m_debug->log("Game is being asked to reload assets live.",DebugMessageType::Info);
+	loadImages();
+	loadSounds();
+	for (auto* pl : m_players) {
+		pl->initVoices();
+		pl->reloadAllAssets();
+		pl->m_movePuyo.hotReload();
+	}
+	m_charSelectMenu->hotRedraw();
+}
+
 bool Game::isFever() const
 {
 	bool fever = false;

--- a/Puyolib/Game.cpp
+++ b/Puyolib/Game.cpp
@@ -411,11 +411,10 @@ void Game::hotReloadAssets() {
 	loadImages();
 	loadSounds();
 	for (auto* pl : m_players) {
-		pl->initVoices();
-		pl->reloadAllAssets();
-		pl->m_movePuyo.hotReload();
+		pl->hotReload();
 	}
 	m_charSelectMenu->hotRedraw();
+	m_debug->log("Hot reloading complete.",DebugMessageType::Debug);
 }
 
 bool Game::isFever() const

--- a/Puyolib/Game.cpp
+++ b/Puyolib/Game.cpp
@@ -292,7 +292,7 @@ int Game::getActivePlayers() const
 	return pl;
 }
 
-void Game::initGame(Frontend* f, AssetManager* as_mgr)
+void Game::initGame(Frontend* f, AssetManagerPriv* as_mgr)
 {
 	m_data = new GameData;
 	m_data->front = f;

--- a/Puyolib/Game.h
+++ b/Puyolib/Game.h
@@ -75,6 +75,7 @@ public:
 	void setWindowFocus(bool focus) const;
 	void setRules();
 	[[nodiscard]] bool isFever() const;
+	void hotReloadAssets();
 
 	// Other
 	void checkEnd();

--- a/Puyolib/Game.h
+++ b/Puyolib/Game.h
@@ -69,7 +69,7 @@ public:
 	bool m_runGame = false;
 
 	// Game related
-	void initGame(Frontend* f, AssetManager* as_mgr);
+	void initGame(Frontend* f, AssetManagerPriv* as_mgr);
 	void playGame();
 	void renderGame();
 	void setWindowFocus(bool focus) const;
@@ -102,7 +102,7 @@ public:
 	int m_activeAtStart = 0;
 
 	// Public variables
-	AssetManager* m_assetManager{};
+	AssetManagerPriv* m_assetManager{};
 	int m_menuSelect = 0;
 	Animation m_readyGoObj {};
 	Animation m_backgroundAnimation {};

--- a/Puyolib/MovePuyo.cpp
+++ b/Puyolib/MovePuyo.cpp
@@ -38,6 +38,13 @@ void Shadow::draw(FeRenderTarget* target)
 	m_sprite.draw(target);
 }
 
+void Shadow::hotReload()
+{
+	m_sprite.setImage((m_data->imgPuyo));
+	m_sprite.setSubRect(16 * kPuyoX - kPuyoX / 2 * (m_color / 3 + 1), 7 * kPuyoY + kPuyoY / 2 * (m_color % 3), kPuyoX / 2, kPuyoY / 2);
+	m_sprite.setCenter(kPuyoX / 4, kPuyoY / 4);
+}
+
 MovePuyo::MovePuyo()
 {
 	m_pos[0].x = 0;
@@ -172,6 +179,7 @@ void MovePuyo::setVisible(bool b)
 {
 	m_visible = b;
 }
+
 
 // Get move puyo ready to be dropped
 void MovePuyo::prepare(MovePuyoType type, Player* player, int color1, int color2)
@@ -1444,6 +1452,36 @@ void MovePuyo::drawQuick()
 	m_quick2.setScaleY(scaleY * m_qScale * corr / 1.5f);
 	m_quick1.draw(m_data->front);
 	m_quick2.draw(m_data->front);
+}
+
+void MovePuyo::hotReload()
+{
+	m_sprite1.setImage(m_data->imgPuyo);
+	m_sprite2.setImage(m_data->imgPuyo);
+	m_spriteEye1.setImage(m_data->imgPuyo);
+	m_spriteEye2.setImage(m_data->imgPuyo);
+
+	// Set sprite
+	m_sprite1.setSubRect(0, kPuyoY * m_color1, kPuyoX, kPuyoY);
+	m_sprite2.setSubRect(0, kPuyoY * m_color2, kPuyoX, kPuyoY);
+	m_spriteEye1.setSubRect(kPuyoX + 2 * kPuyoX * (m_color1 % 2), 12 * kPuyoY + kPuyoY * ((m_color1 / 2) % 2), kPuyoX, kPuyoY);
+	m_spriteEye2.setSubRect(kPuyoX + 2 * kPuyoX * (m_color2 % 2), 12 * kPuyoY + kPuyoY * ((m_color2 / 2) % 2), kPuyoX, kPuyoY);
+	m_sprite1.setCenter(kPuyoX / 2, kPuyoY / 2);
+	m_sprite2.setCenter(kPuyoX / 2, kPuyoY / 2);
+	m_spriteEye1.setCenter(kPuyoX / 2, kPuyoY / 2);
+	m_spriteEye2.setCenter(kPuyoX / 2, kPuyoY / 2);
+	m_quick1.setImage(m_data->imgPuyo);
+	m_quick2.setImage(m_data->imgPuyo);
+	m_quick1.setSubRect(4 * kPuyoX, 13 * kPuyoY, kPuyoX, kPuyoY);
+	m_quick2.setSubRect(4 * kPuyoX, 13 * kPuyoY, kPuyoX, kPuyoY);
+	m_quick1.setTransparency(0);
+	m_quick2.setTransparency(0);
+
+	m_shadow1.hotReload();
+	m_shadow2.hotReload();
+	m_shadow3.hotReload();
+	m_shadow4.hotReload();
+
 }
 
 }

--- a/Puyolib/MovePuyo.h
+++ b/Puyolib/MovePuyo.h
@@ -29,6 +29,7 @@ public:
 		setSprite();
 	}
 	void setVisible(const bool b) { m_sprite.setVisible(b); }
+	void hotReload();
 
 private:
 	void setSprite();
@@ -135,6 +136,7 @@ public:
 	// Draw
 	void draw();
 	void drawQuick();
+	void hotReload();
 };
 
 }

--- a/Puyolib/OtherObjects.cpp
+++ b/Puyolib/OtherObjects.cpp
@@ -19,6 +19,7 @@ int getDigits(const int number)
 }
 
 Particle::Particle(const float x, const float y, const int color, const GameData* data)
+	: m_data(data)
 {
 	m_timer = 0;
 	m_scale = 1;
@@ -65,9 +66,15 @@ bool Particle::shouldDestroy() const
 	return m_timer > 60;
 }
 
+void Particle::reload()
+{
+	m_sprite.setImage(m_data->imgPuyo);
+}
+
 //===========================================================================
 
 ParticleThrow::ParticleThrow(const float x, const float y, const int color, const GameData* data)
+	: m_data(data)
 {
 	// Set sprite
 	m_sprite.setImage(data->imgPuyo);
@@ -105,10 +112,10 @@ void ParticleThrow::play()
 	// Scale
 	m_scale = 1.2f + static_cast<float>(m_timer) * 0.03f;
 	if (m_scale < 0.1f) {
-        m_sprite.setVisible(false);
-    }
+		m_sprite.setVisible(false);
+	}
 
-    // Rotate
+	// Rotate
 	m_rotate += m_rotateSpeed;
 	m_gravityTimer += 0.5f;
 	m_posY += m_gravityTimer;
@@ -120,9 +127,15 @@ bool ParticleThrow::shouldDestroy() const
 	return m_timer > 60;
 }
 
+void ParticleThrow::reload()
+{
+	m_sprite.setImage(m_data->imgPuyo);
+}
+
 //===========================================================================
 
 ChainWord::ChainWord(const GameData* data)
+	: m_data(data)
 {
 	// Set sprite
 	m_spriteChain.setImage(data->imgChain);
@@ -137,10 +150,10 @@ ChainWord::~ChainWord() = default;
 void ChainWord::draw(FeRenderTarget* rw)
 {
 	if (m_visible == false) {
-        return;
-    }
+		return;
+	}
 
-    m_spriteN1.setSubRect(20 * (m_number % 10), 0, 20, 42);
+	m_spriteN1.setSubRect(20 * (m_number % 10), 0, 20, 42);
 	m_spriteN1.setCenter(0, 0);
 	m_spriteN2.setSubRect(20 * ((m_number / 10) % 10), 0, 20, 42);
 	m_spriteN2.setCenter(0, 0);
@@ -182,9 +195,19 @@ void ChainWord::move()
 	}
 }
 
+void ChainWord::reload()
+{
+	m_spriteChain.setImage(m_data->imgChain);
+	m_spriteN1.setImage(m_data->imgChain);
+	m_spriteN2.setImage(m_data->imgChain);
+	m_spriteChain.setSubRect(200, 0, 90, 42);
+	m_spriteChain.setCenter(-6, 0);
+}
+
 //===========================================================================
 
 SecondsObject::SecondsObject(const GameData* data)
+	: m_data(data)
 {
 	// Set sprite
 	m_spritePlus.setImage(data->imgTime);
@@ -238,9 +261,17 @@ void SecondsObject::move()
 	}
 }
 
+void SecondsObject::reload()
+{
+	m_spritePlus.setImage(m_data->imgTime);
+	m_spriteN1.setImage(m_data->imgTime);
+	m_spriteN2.setImage(m_data->imgTime);
+}
+
 //========================================================================================
 
 LightEffect::LightEffect(const GameData* data, const PosVectorFloat& startPv, const PosVectorFloat& middlePv, const PosVectorFloat& endPv)
+	: m_data(data)
 {
 	m_start = startPv;
 	m_middle = middlePv;
@@ -307,9 +338,20 @@ void LightEffect::draw(FeRenderTarget* rw)
 	}
 }
 
+void LightEffect::reload()
+{
+	m_sprite.setImage(m_data->imgLight);
+	m_sprite.setCenter();
+	m_tail.setImage(m_data->imgLightS);
+	m_tail.setCenter();
+	m_hitLight.setImage(m_data->imgLightHit);
+	m_hitLight.setCenter();
+}
+
 //==================================================================
 
 FeverLight::FeverLight(const GameData* data)
+	: m_data(data)
 {
 	m_start = { 0, 0 };
 	m_middle = { 0, 0 };
@@ -347,8 +389,8 @@ void FeverLight::draw(FeRenderTarget* rw)
 
 	const float tempTimer = m_timer / 100.f;
 
-    const float x = m_start.x + (m_middle.x - m_start.x) * tempTimer + (m_middle.x + (m_end.x - m_middle.x) * tempTimer - (m_start.x + (m_middle.x - m_start.x) * tempTimer)) * tempTimer;
-    const float y = m_start.y + (m_middle.y - m_start.y) * tempTimer + (m_middle.y + (m_end.y - m_middle.y) * tempTimer - (m_start.y + (m_middle.y - m_start.y) * tempTimer)) * tempTimer;
+	const float x = m_start.x + (m_middle.x - m_start.x) * tempTimer + (m_middle.x + (m_end.x - m_middle.x) * tempTimer - (m_start.x + (m_middle.x - m_start.x) * tempTimer)) * tempTimer;
+	const float y = m_start.y + (m_middle.y - m_start.y) * tempTimer + (m_middle.y + (m_end.y - m_middle.y) * tempTimer - (m_start.y + (m_middle.y - m_start.y) * tempTimer)) * tempTimer;
 	if (m_timer < 100) {
 		m_sprite.setPosition(x, y);
 		m_sprite.draw(rw);
@@ -363,6 +405,14 @@ void FeverLight::draw(FeRenderTarget* rw)
 	if (m_timer > 200.f) {
 		m_visible = false;
 	}
+}
+
+void FeverLight::reload()
+{
+	m_sprite.setImage(m_data->imgFLight);
+	m_sprite.setCenter();
+	m_hitLight.setImage(m_data->imgFLightHit);
+	m_hitLight.setCenter();
 }
 
 //==================================================================
@@ -440,7 +490,7 @@ void NuisanceTray::update(int trayValue)
 void NuisanceTray::play()
 {
 	for (int i = 0; i < 6; i++) {
-		if (m_timer == 0) {  // NOLINT(clang-diagnostic-float-equal)
+		if (m_timer == 0) { // NOLINT(clang-diagnostic-float-equal)
 			m_animationTimer[i] = 0;
 		} else {
 			m_animationTimer[i] = max(m_timer - static_cast<float>(i) * 3, 0.0f);
@@ -500,6 +550,13 @@ void NuisanceTray::setImage(const int sprite, const int image)
 	m_sprite[sprite].setCenter(kPuyoX / 2, kPuyoY / 2);
 }
 
+void NuisanceTray::reload()
+{
+	for (int i = 0; i < 6; i++) {
+		m_sprite[i].setImage(m_data->imgPuyo);
+	}
+}
+
 //======================================================================================
 
 ScoreCounter::ScoreCounter() = default;
@@ -543,8 +600,8 @@ void ScoreCounter::draw()
 		}
 	} else // Show point x bonus
 	{
-        const int widthB = getDigits(m_bonus);
-        const int widthP = getDigits(m_point);
+		const int widthB = getDigits(m_bonus);
+		const int widthP = getDigits(m_point);
 		for (auto& sprite : m_sprite) {
 			sprite.setVisible(false);
 		}
@@ -573,6 +630,13 @@ void ScoreCounter::setImage(const int spr, const int score)
 {
 	m_sprite[spr].setSubRect(20 * score, 0, 20, 34);
 	m_sprite[spr].setVisible(true);
+}
+
+void ScoreCounter::reload()
+{
+	for (int i = 0; i < 9; i++) {
+		m_sprite[i].setImage(m_data->imgScore);
+	}
 }
 
 }

--- a/Puyolib/OtherObjects.h
+++ b/Puyolib/OtherObjects.h
@@ -23,12 +23,15 @@ public:
 	void play();
     [[nodiscard]] bool shouldDestroy() const;
 
+	void reload();
+
 private:
 	float m_posX, m_posY, m_speedX;
 	float m_gravityTimer;
 	float m_scale;
 	int m_timer;
 	Sprite m_sprite;
+	const GameData* m_data;
 };
 
 // Puyos that are "thrown" out
@@ -46,6 +49,7 @@ public:
 	void draw(FeRenderTarget*);
 	void play();
     [[nodiscard]] bool shouldDestroy() const;
+	void reload();
 
 private:
 	float m_posX = 0.f, m_posY = 0.f, m_speedX = 0.f, m_rotateSpeed = 0.f;
@@ -53,6 +57,7 @@ private:
 	float m_scale = 1.f, m_rotate = 0.;
 	int m_timer = 0;
 	Sprite m_sprite {};
+	const GameData* m_data;
 };
 
 // Object that shows the word XX chain
@@ -71,12 +76,14 @@ public:
 	void draw(FeRenderTarget* rw);
 	void showAt(float x, float y, int n);
 	void move();
+	void reload();
 
 private:
 	float m_posX = 0.f, m_posY = 0.f, m_scale = 1.f;
 	int m_timer = 100, m_number = 0;
 	bool m_visible = false;
 	Sprite m_spriteN1 {}, m_spriteN2 {}, m_spriteChain {};
+	const GameData* m_data;
 };
 
 // Object that shows the word +XX seconds
@@ -95,12 +102,14 @@ public:
 	void draw(FeRenderTarget* rw);
 	void showAt(float x, float y, int n);
 	void move();
+	void reload();
 
 private:
 	float m_posX = 0.f, m_posY = 0.f, m_scale = 1.f;
 	int m_timer = 100, m_number = 0;
 	bool m_visible = false;
 	Sprite m_spriteN1 {}, m_spriteN2 {}, m_spritePlus {};
+	const GameData* m_data;
 };
 
 // Light that represents garbage
@@ -120,6 +129,7 @@ public:
 	void setEnd(const PosVectorFloat& pv) { m_end = pv; }
 	void setMiddle(const PosVectorFloat& pv) { m_middle = pv; }
 	void draw(FeRenderTarget* rw);
+	void reload();
 
 private:
 	bool m_visible = false;
@@ -128,6 +138,7 @@ private:
 	Sprite m_sprite {};
 	Sprite m_tail {};
 	Sprite m_hitLight {};
+	const GameData* m_data;
 };
 
 // Light that represents a count for the fever gauge
@@ -145,6 +156,7 @@ public:
 	void setTimer(float timer);
 	void init(const PosVectorFloat&, const PosVectorFloat&, const PosVectorFloat&);
 	void draw(FeRenderTarget* rw);
+	void reload();
 
 private:
 	bool m_visible = false;
@@ -153,6 +165,7 @@ private:
 	float m_speed = 0.f;
 	Sprite m_sprite {};
 	Sprite m_hitLight {};
+	const GameData* m_data;
 };
 
 // The 6 nuisance puyos above the field
@@ -175,6 +188,7 @@ public:
 	void draw();
 	void setImage(int sprite, int image);
 	void setDarken(const bool d) { m_darken = d; }
+	void reload();
 
 private:
 	float m_timer = 0.f;
@@ -203,6 +217,7 @@ public:
 	void setCounter(int);
 	void setPointBonus(int, int);
 	void draw();
+	void reload();
 
 private:
 	int m_timer = 0;

--- a/Puyolib/Player.cpp
+++ b/Puyolib/Player.cpp
@@ -2580,55 +2580,6 @@ void Player::prepareDisconnect()
 
 #pragma region Rendering
 
-void Player::reloadAllAssets()
-{
-	m_fieldFeverSprite.setImage(m_data->imgFieldFever);
-	m_allClearSprite.setImage(m_data->imgAllClear);
-	m_crossSprite.setImage(m_data->imgPuyo);
-	m_crossSprite.setSubRect(7 * kPuyoX, 12 * kPuyoY, kPuyoX, kPuyoY);
-	m_crossSprite.setCenter(0, 0);
-	m_winSprite.setImage(m_data->imgWin);
-	m_loseSprite.setImage(m_data->imgLose);
-	for (auto & i : m_colorMenuBorder) {
-		i.setImage(m_data->imgPlayerBorder);
-	}
-	for (auto & i : m_spice) {
-		i.setImage(m_data->imgSpice);
-	}
-	m_charHolderSprite.setImage(m_data->imgCharHolder);
-	m_rematchIcon.setImage(m_data->imgCheckMark);
-	if (m_playerNum==1) {
-		m_fieldSprite.setImage(m_data->imgField1);
-		m_borderSprite.setImage(m_data->imgBorder1);
-	}
-	else if (m_playerNum>1) {
-		m_fieldSprite.setImage(m_data->imgField2);
-		m_borderSprite.setImage(m_data->imgBorder2);
-	}
-	m_currentCharacterSprite.setImage(m_currentGame->m_assetManager->loadImage(ImageToken::imgCharIcon, m_character));
-	for (auto& i : m_dropSet) {
-		i.setImage(m_currentGame->m_assetManager->loadImage(ImageToken::imgDropSet));
-	}
-	setFieldImage(m_character);
-	const PosVectorFloat offset(
-		m_activeField->getProperties().centerX * 1,
-		m_activeField->getProperties().centerY / 2.0f * 1);
-	if (m_currentGame->m_players.size() <= 10)
-		m_characterAnimation.init(m_data, offset, 1, m_currentGame->m_assetManager->getAnimationFolder(m_character));
-	else
-		m_characterAnimation.init(m_data, offset, 1, "");
-	for (auto* sec : m_secondsObj) {
-		sec->reload();
-	}
-	if (m_chainWord!=nullptr) {
-		m_chainWord->reload();
-	}
-
-	m_scoreCounter.reload();
-
-	m_activeField->hotReload();
-
-}
 
 // Draw everything from the player
 void Player::draw()
@@ -2922,6 +2873,56 @@ void Player::setDropSetSprite(int x, int y, PuyoCharacter pc)
 	}
 }
 
+void Player::hotReload()
+{
+	initVoices();
+	m_fieldFeverSprite.setImage(m_data->imgFieldFever);
+	m_allClearSprite.setImage(m_data->imgAllClear);
+	m_crossSprite.setImage(m_data->imgPuyo);
+	m_crossSprite.setSubRect(7 * kPuyoX, 12 * kPuyoY, kPuyoX, kPuyoY);
+	m_crossSprite.setCenter(0, 0);
+	m_winSprite.setImage(m_data->imgWin);
+	m_loseSprite.setImage(m_data->imgLose);
+	for (auto & i : m_colorMenuBorder) {
+		i.setImage(m_data->imgPlayerBorder);
+	}
+	for (auto & i : m_spice) {
+		i.setImage(m_data->imgSpice);
+	}
+	m_charHolderSprite.setImage(m_data->imgCharHolder);
+	m_rematchIcon.setImage(m_data->imgCheckMark);
+	if (m_playerNum==1) {
+		m_fieldSprite.setImage(m_data->imgField1);
+		m_borderSprite.setImage(m_data->imgBorder1);
+	}
+	else if (m_playerNum>1) {
+		m_fieldSprite.setImage(m_data->imgField2);
+		m_borderSprite.setImage(m_data->imgBorder2);
+	}
+	m_currentCharacterSprite.setImage(m_currentGame->m_assetManager->loadImage(ImageToken::imgCharIcon, m_character));
+	for (auto& i : m_dropSet) {
+		i.setImage(m_currentGame->m_assetManager->loadImage(ImageToken::imgDropSet));
+	}
+	setFieldImage(m_character);
+	const PosVectorFloat offset(
+		m_activeField->getProperties().centerX * 1,
+		m_activeField->getProperties().centerY / 2.0f * 1);
+	if (m_currentGame->m_players.size() <= 10)
+		m_characterAnimation.init(m_data, offset, 1, m_currentGame->m_assetManager->getAnimationFolder(m_character));
+	else
+		m_characterAnimation.init(m_data, offset, 1, "");
+	for (auto* sec : m_secondsObj) {
+		sec->reload();
+	}
+	if (m_chainWord!=nullptr) {
+		m_chainWord->reload();
+	}
+	m_movePuyo.hotReload();
+	m_scoreCounter.reload();
+	m_nextPuyo.initImage();
+	m_activeField->hotReload();
+
+}
 
 #pragma endregion
 

--- a/Puyolib/Player.cpp
+++ b/Puyolib/Player.cpp
@@ -2580,6 +2580,56 @@ void Player::prepareDisconnect()
 
 #pragma region Rendering
 
+void Player::reloadAllAssets()
+{
+	m_fieldFeverSprite.setImage(m_data->imgFieldFever);
+	m_allClearSprite.setImage(m_data->imgAllClear);
+	m_crossSprite.setImage(m_data->imgPuyo);
+	m_crossSprite.setSubRect(7 * kPuyoX, 12 * kPuyoY, kPuyoX, kPuyoY);
+	m_crossSprite.setCenter(0, 0);
+	m_winSprite.setImage(m_data->imgWin);
+	m_loseSprite.setImage(m_data->imgLose);
+	for (auto & i : m_colorMenuBorder) {
+		i.setImage(m_data->imgPlayerBorder);
+	}
+	for (auto & i : m_spice) {
+		i.setImage(m_data->imgSpice);
+	}
+	m_charHolderSprite.setImage(m_data->imgCharHolder);
+	m_rematchIcon.setImage(m_data->imgCheckMark);
+	if (m_playerNum==1) {
+		m_fieldSprite.setImage(m_data->imgField1);
+		m_borderSprite.setImage(m_data->imgBorder1);
+	}
+	else if (m_playerNum>1) {
+		m_fieldSprite.setImage(m_data->imgField2);
+		m_borderSprite.setImage(m_data->imgBorder2);
+	}
+	m_currentCharacterSprite.setImage(m_currentGame->m_assetManager->loadImage(ImageToken::imgCharIcon, m_character));
+	for (auto& i : m_dropSet) {
+		i.setImage(m_currentGame->m_assetManager->loadImage(ImageToken::imgDropSet));
+	}
+	setFieldImage(m_character);
+	const PosVectorFloat offset(
+		m_activeField->getProperties().centerX * 1,
+		m_activeField->getProperties().centerY / 2.0f * 1);
+	if (m_currentGame->m_players.size() <= 10)
+		m_characterAnimation.init(m_data, offset, 1, m_currentGame->m_assetManager->getAnimationFolder(m_character));
+	else
+		m_characterAnimation.init(m_data, offset, 1, "");
+	for (auto* sec : m_secondsObj) {
+		sec->reload();
+	}
+	if (m_chainWord!=nullptr) {
+		m_chainWord->reload();
+	}
+
+	m_scoreCounter.reload();
+
+	m_activeField->hotReload();
+
+}
+
 // Draw everything from the player
 void Player::draw()
 {
@@ -2871,6 +2921,7 @@ void Player::setDropSetSprite(int x, int y, PuyoCharacter pc)
 		}
 	}
 }
+
 
 #pragma endregion
 

--- a/Puyolib/Player.h
+++ b/Puyolib/Player.h
@@ -280,6 +280,7 @@ public:
 
 	// Debugging
 	int m_debug = 0;
+	void reloadAllAssets();
 
 	std::vector<MessageEvent> m_recordMessages;
 

--- a/Puyolib/Player.h
+++ b/Puyolib/Player.h
@@ -280,7 +280,7 @@ public:
 
 	// Debugging
 	int m_debug = 0;
-	void reloadAllAssets();
+	void hotReload();
 
 	std::vector<MessageEvent> m_recordMessages;
 

--- a/Puyolib/Puyo.cpp
+++ b/Puyolib/Puyo.cpp
@@ -82,6 +82,10 @@ Puyo* Puyo::clone()
 	return new Puyo(*this);
 }
 
+void Puyo::reloadSprite() {
+	m_sprite.setImage(m_data->imgPuyo);
+}
+
 // Add to acceleration and set position
 void Puyo::addAccelerationY(float val)
 {

--- a/Puyolib/Puyo.h
+++ b/Puyolib/Puyo.h
@@ -24,6 +24,7 @@ public:
 	Puyo(const Puyo& self); // Copy constructor
 	virtual ~Puyo();
 	virtual Puyo* clone();
+	void reloadSprite();
 
 	// Get and set
 	[[nodiscard]] int posX() const { return m_posX; } // Returns indexed position


### PR DESCRIPTION
Allows the user to dynamically apply changes of some preferences to existing `Game`s after closing the Settings dialog in the Client. Additionally separates `AssetManager` into two classes (a base class and generated helper with access to the game's parameters) `AssetBundle`s are now front-end agnostic and take `ppvs::Frontend*` as a parameter for required actions. 

**Requires** further testing before merging (live changing of preferences for multiple Game instances works, relaunching is fully functional for me, ClientNG works, memory usage and leaks haven't been analyzed) 