### PR TITLE
Fix the problem of not showing AllClear Sprites when you win in Endless Fever or Fever while you do AllClear at same time

### DIFF
--- a/Puyolib/Player.cpp
+++ b/Puyolib/Player.cpp
@@ -2799,6 +2799,8 @@ void Player::drawWin()
 		m_winSprite.setPosition(position.x, position.y + 10.f * sin(static_cast<float>(m_loseWinTimer) / 20.f));
 		m_winSprite.setScale(1.f);
 		m_winSprite.draw(m_data->front);
+		m_allClearSprite.setVisible(true);
+		m_allClearSprite.setTransparency(1);
 	}
 }
 


### PR DESCRIPTION
self-explanatory, this was similar problems with #57 but only in case of you winning and doing allclear at same time.