### PR TITLE
Client: stop music playback when no Game objects are present

### DIFF
--- a/Client/gamemanager.cpp
+++ b/Client/gamemanager.cpp
@@ -248,6 +248,7 @@ void GameManager::gameDestroyed(GameWidget* game)
 	games.removeOne(game);
 
 	if (games.isEmpty()) {
+		pvsApp->setMusicMode(PVSApplication::MusicMode::MusicOff); // No Game present, do not play music
 	}
 }
 


### PR DESCRIPTION
Previously, when you closed the last Game window, the music would not stop playing. It is desired that music stops when the Game closes. When multiple games are present, do nothing when a Game closes.