### PR TITLE
Internal and vendored libraries should always be static

### DIFF
--- a/Audiolib/CMakeLists.txt
+++ b/Audiolib/CMakeLists.txt
@@ -6,7 +6,7 @@ add_compile_definitions(
     FLOATING_POINT
 )
 
-add_library(Audiolib
+add_library(Audiolib STATIC
     audiolib.cpp
     minimp3.c
     stream.cpp

--- a/Inputlib/CMakeLists.txt
+++ b/Inputlib/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_compile_definitions(INPUTLIB)
 
-add_library(Inputlib
+add_library(Inputlib STATIC
     driver.cpp
     drivers/sdldriver.cpp
     drivers/dinputdriver.cpp

--- a/PVS_ENet/CMakeLists.txt
+++ b/PVS_ENet/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(PVS_ENet 
+add_library(PVS_ENet STATIC
     PVS_Channel.cpp
     PVS_Channel.h
     PVS_Client.cpp

--- a/Puyolib/CMakeLists.txt
+++ b/Puyolib/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(Puyolib
+add_library(Puyolib STATIC
     tinyxmlparser.cpp
     tinyxmlerror.cpp
     tinyxml.cpp

--- a/ThirdParty/enet/enet/CMakeLists.txt
+++ b/ThirdParty/enet/enet/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(include)
 
-add_library(ENet
+add_library(ENet STATIC
     callbacks.c
     compress.c
     host.c

--- a/ThirdParty/vgmstream/vgmstream/CMakeLists.txt
+++ b/ThirdParty/vgmstream/vgmstream/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(VgmStream
+add_library(VgmStream STATIC
     src/vgmstream.c
     src/util.c
     src/streamfile.c


### PR DESCRIPTION
Forces internal and vendored libraries to be compiled and linked statically. We don't want these libraries to wind up installed system-wide, so we don't want them to be shared libraries. PuyoVS doesn't export any libraries that are intended to be consumed by other programs. This is needed in case `-DBUILD_SHARED_LIBS=ON` is set.

Fixes #67.