### PR TITLE
Client: Do not crash in SettingsDialog if the User folder is not set

### DIFF
--- a/Puyolib/AssetBundle.cpp
+++ b/Puyolib/AssetBundle.cpp
@@ -178,8 +178,14 @@ void FolderAssetBundle::reload()
 std::list<std::string> FolderAssetBundle::listPuyoSkins()
 {
 	std::list<std::string> new_list;
-	for (auto folder : std::filesystem::directory_iterator(m_translator->token2fn("%base%/") + kFolderUserPuyo)) {
-		new_list.push_back((folder.path().stem()).string());
+	try {
+		for (auto folder : std::filesystem::directory_iterator(m_translator->token2fn("%base%/") + kFolderUserPuyo)) {
+			new_list.push_back((folder.path().stem()).string());
+		}
+	}
+	catch (std::filesystem::filesystem_error& e) {
+		// Illegal path, fail silent
+		std::cerr << "Failed to locate bundles in " << m_translator->token2fn("%base%/") + kFolderUserPuyo<<std::endl;
 	}
 	return new_list;
 }
@@ -187,10 +193,16 @@ std::list<std::string> FolderAssetBundle::listPuyoSkins()
 std::list<std::string> FolderAssetBundle::listBackgrounds()
 {
 	std::list<std::string> new_list;
-	for (auto folder : std::filesystem::directory_iterator(m_translator->token2fn("%base%/") + kFolderUserBackgrounds)) {
-		if (folder.is_directory()) {
-			new_list.push_back((folder.path().filename()).string());
+	try {
+		for (auto folder : std::filesystem::directory_iterator(m_translator->token2fn("%base%/") + kFolderUserBackgrounds)) {
+			if (folder.is_directory()) {
+				new_list.push_back((folder.path().filename()).string());
+			}
 		}
+	}
+	catch (std::filesystem::filesystem_error& e) {
+		// Illegal path, fail silent
+		std::cerr << "Failed to locate bundles in " << m_translator->token2fn("%base%/") + kFolderUserBackgrounds<<std::endl;
 	}
 	return new_list;
 }
@@ -198,10 +210,16 @@ std::list<std::string> FolderAssetBundle::listBackgrounds()
 std::list<std::string> FolderAssetBundle::listSfx()
 {
 	std::list<std::string> new_list;
-	for (auto folder : std::filesystem::directory_iterator(m_translator->token2fn("%base%/") + kFolderUserSounds)) {
-		if (folder.is_directory()) {
-			new_list.push_back((folder.path().filename()).string());
+	try {
+		for (auto folder : std::filesystem::directory_iterator(m_translator->token2fn("%base%/") + kFolderUserSounds)) {
+			if (folder.is_directory()) {
+				new_list.push_back((folder.path().filename()).string());
+			}
 		}
+	}
+	catch (std::filesystem::filesystem_error& e) {
+		// Illegal path, fail silent
+		std::cerr << "Failed to locate bundles in " << m_translator->token2fn("%base%/") + kFolderUserSounds<<std::endl;
 	}
 	return new_list;
 }
@@ -209,10 +227,16 @@ std::list<std::string> FolderAssetBundle::listSfx()
 std::list<std::string> FolderAssetBundle::listCharacterSkins()
 {
 	std::list<std::string> new_list;
-	for (auto folder : std::filesystem::directory_iterator(m_translator->token2fn("%base%/") + kFolderUserCharacter)) {
-		if (folder.is_directory()) {
-			new_list.push_back((folder.path().filename()).string());
+	try {
+		for (auto folder : std::filesystem::directory_iterator(m_translator->token2fn("%base%/") + kFolderUserCharacter)) {
+			if (folder.is_directory()) {
+				new_list.push_back((folder.path().filename()).string());
+			}
 		}
+	}
+	catch (std::filesystem::filesystem_error& e) {
+		// Illegal path, fail silent
+		std::cerr << "Failed to locate bundles in " << m_translator->token2fn("%base%/") + kFolderUserCharacter<<std::endl;
 	}
 	return new_list;
 }


### PR DESCRIPTION
As a consequence of #52, SettingsDialog might look for user data in places it might not be present, particularly the "." folder. Previously, this throws a std::filesystem::error that crashes the client. For now, let's replace the hard crash with a message in the standard error. 

For the future, I suggest throwing a pop-up with more information if no asset of a particular type is found with a hyperlink to the Download page and information if not a single folder is available. Instructions for adding more folders for package maintainers should be provided. There also seems to be a bug where we have to resort to using "/./" in the file path, which I find very off-putting, prone to errors (when the path is taken literally without resolution) and possibly platform dependent.